### PR TITLE
Execute the user's code through the setup script

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,13 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       }
 
+      const activeTextEditor : vscode.TextEditor|undefined = vscode.window.activeTextEditor;
+      let currentFileAbsPath : string = "";
+
+      if (activeTextEditor) {
+        currentFileAbsPath = activeTextEditor.document.fileName;
+      }
+
       // Get the Python script path (And the special URI to use with the webview)
       const onDiskPath = vscode.Uri.file(
         path.join(context.extensionPath, "out", "setup.py")
@@ -60,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
       const scriptPath = onDiskPath.with({ scheme: "vscode-resource" });
 
       // Create the Python process
-      let childProcess = cp.spawn("python", [scriptPath.fsPath]);
+      let childProcess = cp.spawn("python", [scriptPath.fsPath, currentFileAbsPath]);
 
       let dataForTheProcess = "hello";
       let dataFromTheProcess = "";

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,3 +6,7 @@ abs_path_to_parent_dir = os.path.abspath(os.getcwd())
 library_name = "adafruit_circuitplayground"
 abs_path_to_lib = os.path.join(abs_path_to_parent_dir, library_name)
 sys.path.insert(0, abs_path_to_lib)
+
+# Execute the user's code.py file
+abs_path_to_code_file = sys.argv[1]
+exec(open(abs_path_to_code_file).read())


### PR DESCRIPTION
**Description:**
- Pass the path to the file that is currently in focus (for the user it should be `code.py` or `main.py`) and sends it as an argument to the setup script `setup.py`. `setup.py` will execute the user's script through the path that was passed as an argument.

**Limitations:**
- When we run the command "Open Simulator", the Webview becomes the tab that is in focus. The user must click back on their `code.py` file before running the command "Run the Simulator" or else the user's script file won't be sent as the script to be executed.

**Suggestions:**
- Try to find a way to make it so `code.py` / `main.py` will be the editor in focus after we open the simulator