### PR TITLE
Move python lib into the out directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "compile": "npm-run-all compile:*",
     "compile:extension": "tsc",
     "compile:views": "webpack --mode development",
+    "compile:python": "xcopy src\\setup.py out\\ /I /Y && xcopy src\\adafruit_circuitplayground out\\adafruit_circuitplayground /S /I /E /Y",
     "watch": "npm-run-all -p watch:*",
     "watch:extension": "tsc --watch",
     "watch:views": "webpack --watch --mode development",


### PR DESCRIPTION
In order for vscode to package our extension correctly, we need to move the python files into the output directory. Deciding to do this within NPM rather than in the build script as this makes testing much easier.

One thing to note, I'm using DOS commands to move the files. I think not having this as cross platform will be ok as long as the VM and the machines we develop on are Windows machines. If anyone has any strong opinions on finding a better solution right now then we can look at that instead, but this is a solution for now

Main area of concern I see is once this project is open source people using UNIX won't be able to move their python over with the npm script, but that is a bit in the future

### Testing
- [ ] make sure that you can build the project with `npm run compile` and that the extension works as expected with the changes you make to the python files or the javascript
- [ ] you could also package the extension and see if it runs (I did this and it worked fine on my machine)