### PR TITLE
State changes fix

### DIFF
--- a/src/adafruit_circuitplayground/pixel.py
+++ b/src/adafruit_circuitplayground/pixel.py
@@ -10,11 +10,14 @@ class Pixel:
         # Send the state to the extension so that React re-renders the Webview
         print(json.dumps(self._state) + '\0', end='')
         sys.stdout.flush()
+
+    def show_if_auto_write(self):
+        if self._auto_write:
+            self.show()
     
     def __setitem__(self, index, val):
         self._state['pixels'][index] = self.extract_pixel_value(val)
-        if self._auto_write:
-            self.show()
+        self.show_if_auto_write()
 
     def __getitem__(self, index):
         return self._state['pixels'][index]
@@ -37,8 +40,7 @@ class Pixel:
     def fill(self, val):
         for index in range(len(self._state['pixels'])):
             self._state['pixels'][index] = self.extract_pixel_value(val)
-        if self._auto_write:
-            self.show()
+        self.show_if_auto_write()
 
     def hex_to_rgb(self, hexValue):
         hexValue = hexValue.lstrip('#')
@@ -60,8 +62,7 @@ class Pixel:
         if not self.valid_brightness(brightness):
             raise ValueError('The brightness value should be a number between 0 and 1.')
         self._state['brightness'] = brightness
-        if self._auto_write:
-            self.show()
+        self.show_if_auto_write()
 
     def valid_brightness(self, brightness):
         return (type(brightness) is float or type(brightness) is int) and (brightness >= 0 and brightness <= 1)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Create the Python process (after killing the one running if any)
       if (childProcess != undefined) {
+        // TODO: We need to check the process was correctly killed
         childProcess.kill();
       }
       childProcess = cp.spawn("python", [scriptPath.fsPath, currentFileAbsPath]);
@@ -81,7 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
         dataFromTheProcess = data.toString();
         if (currentPanel) {
           // Process the data from the process and send one state at a time
-          dataFromTheProcess.split("\0"). forEach(message => {
+          dataFromTheProcess.split("\0").forEach(message => {
             if (currentPanel && message.length > 0 && message != oldState) {
               console.log("Process output = ", message);
               currentPanel.webview.postMessage(JSON.parse(message));


### PR DESCRIPTION
**Description:**

- Killing previous processes running before spawning new ones
- Adding an end of JSON character to make sure we process all the states received one at a time
- With those changes, we can change the python code in the extension and re-run the 'run' command to see the new code get executed.


**Limitations:**

- We added a '_auto_write' attribute because calling show in all assignment methods causes deterioration in the simulator performances. This needs further investigations, after which we can set '_auto_write' to True.
- We're currently killing an spawning a new Python process every time the 'run' command gets called. In the future, we can look into how we can update the user's code without creating a new process each time.


**Test Plan:**

- You can change the code, and run the 'run' command without having to reload the extension. The new code should be running.
- To see the auto_write possibility, just change it to True in the Pixel.py file. This way you don't need to call show() in the code you're writing, but it infers additional times before the simulator renders properly.
 