### PR TITLE
Opening the simulator webview after the template file is opened

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,19 +180,19 @@ export function activate(context: vscode.ExtensionContext) {
               telemetryAI.trackFeatureUsage(
                 TelemetryEventName.CLICK_DIALOG_TUTORIALS
               );
-            }
+            };
             utils.showPrivacyModal(okAction);
           }
         });
     }
 
-    openWebview();
-
     // tslint:disable-next-line: ban-comma-operator
     vscode.workspace
       .openTextDocument({ content: file, language: "python" })
       .then((template: vscode.TextDocument) => {
-        vscode.window.showTextDocument(template, 1, false);
+        vscode.window.showTextDocument(template, 1, false).then(() => {
+          openWebview();
+        });
       }),
       // tslint:disable-next-line: no-unused-expression
       (error: any) => {
@@ -408,7 +408,7 @@ export function activate(context: vscode.ExtensionContext) {
                       telemetryAI.trackFeatureUsage(
                         TelemetryEventName.CLICK_DIALOG_HELP_DEPLOY_TO_DEVICE
                       );
-                    }
+                    };
                     utils.showPrivacyModal(okAction);
                   }
                 });


### PR DESCRIPTION
# Description:

This PR is a bug fix (BUG : 31513) : 
When no file is opened and we run the `New Project` command the previous behavior used to be having the simulator hidden behind the template code. 
Now the simulator's webview opens on the right panel after the template code has been loaded.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# Testing:
- [x] Try closing all tabs and run the `New project` command and make sure the Simulator is opening in the right panel and the template code in the left panel.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
