### PR TITLE
Renaming 'New Project' to 'New File'

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -9,7 +9,7 @@ Commands are accessible through :
 
 - **Open Simulator** : opens the webview of the simulator.
 
-- **New Project** : opens an unsaved file with links to help you and a code snippet that you can save as `code.py` / `main.py`.  
+- **New File** : opens an unsaved file with links to help you and a code snippet that you can save as `code.py` / `main.py`.  
   _(**Note :** will open the simulator webview if it's not open yet)_.
 
 - **Run Simulator** : run the code you have open on the simulator (make sure you've clicked on a valid code file).  

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -15,7 +15,7 @@ Through the Application Insights API, telemetry events are collected on Pacifica
 
 |     **Property**       | **Note**                                                                                             |
 | :-------------------:  | ---------------------------------------------------------------------------------------------------- |
-|    **Event Name**      | Unique event name/descriptor for the event. For ex: Pacifica/COMMAND_NEW_PROJECT                     |
+|    **Event Name**      | Unique event name/descriptor for the event. For ex: Pacifica/COMMAND_NEW_FILE                        |
 | **VS Code Session ID** | A unique identifier for the current session (changes each time the editor is started)                |
 | **VS Code Machine ID** | A unique identifier for the computer                                                                 |
 |  **VS Code Version**   | VS Code version being used by the user                                                               |

--- a/locales/en/out/constants.i18n.json
+++ b/locales/en/out/constants.i18n.json
@@ -20,7 +20,7 @@
   "info.extensionActivated": "Congratulations, your extension Adafruit_Simulator is now active!",
   "info.firstTimeWebview": "To reopen the simulator click on the \"Open Simulator\" button on the upper right corner of the text editor, or select the command \"Open Simulator\" from command palette.",
   "error.invalidFileExtensionDebug": "The file you tried to run isn\\'t a Python file.",
-  "info.newProject": "New to Python or Circuit Playground Express project? We are here to help!",
+  "info.newFile": "New to Python or the Circuit Playground Express? We are here to help!",
   "info.redirect": "You are being redirected.",
   "info.runningCode": "Running user code",
   "info.privacyStatement": "Privacy Statement",

--- a/locales/en/package.i18n.json
+++ b/locales/en/package.i18n.json
@@ -2,7 +2,7 @@
   "pacificaExtension.commands.label": "Pacifica",
   "pacificaExtension.commands.openSimulator": "Open Simulator",
   "pacificaExtension.commands.runSimulator": "Run Simulator",
-  "pacificaExtension.commands.newProject": "New Project",
+  "pacificaExtension.commands.newFile": "New File",
   "pacificaExtension.commands.runDevice": "Deploy to Device",
   "pacificaExtension.configuration.title": "Pacfica configuration",
   "pacificaExtension.configuration.properties.open": "Whether to show 'Open Simulator' icon in editor title menu.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7011,8 +7011,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7033,14 +7032,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7055,20 +7052,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7185,8 +7179,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7198,7 +7191,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7213,7 +7205,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7221,14 +7212,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7247,7 +7236,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7328,8 +7316,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7341,7 +7328,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7427,8 +7413,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7464,7 +7449,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7484,7 +7468,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7528,14 +7511,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "activationEvents": [
     "onCommand:pacifica.openSimulator",
     "onCommand:pacifica.runSimulator",
-    "onCommand:pacifica.newProject",
+    "onCommand:pacifica.newFile",
     "onCommand:pacifica.runDevice",
     "onDebug"
   ],
@@ -52,8 +52,8 @@
         }
       },
       {
-        "command": "pacifica.newProject",
-        "title": "%pacificaExtension.commands.newProject%",
+        "command": "pacifica.newFile",
+        "title": "%pacificaExtension.commands.newFile%",
         "category": "%pacificaExtension.commands.label%"
       },
       {

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,7 @@
   "pacificaExtension.commands.label": "Pacifica",
   "pacificaExtension.commands.openSimulator": "Open Simulator",
   "pacificaExtension.commands.runSimulator": "Run Simulator",
-  "pacificaExtension.commands.newProject": "New Project",
+  "pacificaExtension.commands.newFile": "New File",
   "pacificaExtension.commands.runDevice": "Deploy to Device",
   "pacificaExtension.configuration.title": "Pacfica configuration",
   "pacificaExtension.configuration.properties.open": "Whether to show 'Open Simulator' icon in editor title menu.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,7 +34,7 @@ export const CONSTANTS = {
     ),
     NO_FILE_TO_RUN: localize(
       "error.noFileToRun",
-      '[ERROR] We can\'t find a Python file to run. Please make sure you select or open a new ".py" code file, or use the "New Project" command to get started and see useful links.\n'
+      '[ERROR] We can\'t find a Python file to run. Please make sure you select or open a new ".py" code file, or use the "New File" command to get started and see useful links.\n'
     ),
     NO_PROGRAM_FOUND_DEBUG: localize(
       "error.noProgramFoundDebug",
@@ -86,9 +86,9 @@ export const CONSTANTS = {
       "info.invalidFileNameDebug",
       'The file you tried to debug isn\'t named "code.py" or "main.py". Rename your file if you want your code to work on your actual device.'
     ),
-    NEW_PROJECT: localize(
-      "info.newProject",
-      "New to Python or Circuit Playground Express project? We are here to help!"
+    NEW_FILE: localize(
+      "info.newFile",
+      "New to Python or the Circuit Playground Express? We are here to help!"
     ),
     REDIRECT: localize("info.redirect", "You are being redirected."),
     RUNNING_CODE: localize("info.runningCode", "Running user code"),
@@ -123,7 +123,7 @@ export enum TelemetryEventName {
 
   // Extension commands
   COMMAND_DEPLOY_DEVICE = "COMMAND.DEPLOY.DEVICE",
-  COMMAND_NEW_PROJECT = "COMMAND.NEW.PROJECT",
+  COMMAND_NEW_FILE = "COMMAND.NEW.FILE",
   COMMAND_OPEN_SIMULATOR = "COMMAND.OPEN.SIMULATOR",
   COMMAND_RUN_SIMULATOR = "COMMAND.RUN.SIMULATOR",
 
@@ -141,14 +141,14 @@ export enum TelemetryEventName {
 
   ERROR_PYTHON_DEVICE_PROCESS = "ERROR.PYTHON.DEVICE.PROCESS",
   ERROR_PYTHON_PROCESS = "ERROR.PYTHON.PROCESS",
-  ERROR_COMMAND_NEW_PROJECT = "ERROR.COMMAND.NEW.PROJECT",
+  ERROR_COMMAND_NEW_FILE = "ERROR.COMMAND.NEW.FILE",
   ERROR_DEPLOY_WITHOUT_DEVICE = "ERROR.DEPLOY.WITHOUT.DEVICE",
 
   SUCCESS_COMMAND_DEPLOY_DEVICE = "SUCCESS.COMMAND.DEPLOY.DEVICE",
 
   // Performance
   PERFORMANCE_DEPLOY_DEVICE = "PERFORMANCE.DEPLOY.DEVICE",
-  PERFORMANCE_NEW_PROJECT = "PERFORMANCE.NEW.PROJECT",
+  PERFORMANCE_NEW_FILE = "PERFORMANCE.NEW.FILE",
   PERFORMANCE_OPEN_SIMULATOR = "PERFORMANCE.OPEN.SIMULATOR"
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ let telemetryAI: TelemetryAI;
 let pythonExecutableName: string = "python";
 // Notification booleans
 let firstTimeClosed: boolean = true;
-let shouldShowNewProject: boolean = true;
+let shouldShowNewFile: boolean = true;
 let shouldShowInvalidFileNamePopup: boolean = true;
 
 function loadScript(context: vscode.ExtensionContext, scriptPath: string) {
@@ -162,17 +162,17 @@ export async function activate(context: vscode.ExtensionContext) {
     const filePath = __dirname + path.sep + fileName;
     const file = fs.readFileSync(filePath, "utf8");
 
-    if (shouldShowNewProject) {
+    if (shouldShowNewFile) {
       vscode.window
         .showInformationMessage(
-          CONSTANTS.INFO.NEW_PROJECT,
+          CONSTANTS.INFO.NEW_FILE,
           DialogResponses.DONT_SHOW,
           DialogResponses.EXAMPLE_CODE,
           DialogResponses.TUTORIALS
         )
         .then((selection: vscode.MessageItem | undefined) => {
           if (selection === DialogResponses.DONT_SHOW) {
-            shouldShowNewProject = false;
+            shouldShowNewFile = false;
             telemetryAI.trackFeatureUsage(
               TelemetryEventName.CLICK_DIALOG_DONT_SHOW
             );
@@ -204,19 +204,19 @@ export async function activate(context: vscode.ExtensionContext) {
       // tslint:disable-next-line: no-unused-expression
       (error: any) => {
         telemetryAI.trackFeatureUsage(
-          TelemetryEventName.ERROR_COMMAND_NEW_PROJECT
+          TelemetryEventName.ERROR_COMMAND_NEW_FILE
         );
         console.error(`Failed to open a new text document:  ${error}`);
       };
   };
 
-  const newProject: vscode.Disposable = vscode.commands.registerCommand(
-    "pacifica.newProject",
+  const newFile: vscode.Disposable = vscode.commands.registerCommand(
+    "pacifica.newFile",
     () => {
-      telemetryAI.trackFeatureUsage(TelemetryEventName.COMMAND_NEW_PROJECT);
+      telemetryAI.trackFeatureUsage(TelemetryEventName.COMMAND_NEW_FILE);
       telemetryAI.runWithLatencyMeasure(
         openTemplateFile,
-        TelemetryEventName.PERFORMANCE_NEW_PROJECT
+        TelemetryEventName.PERFORMANCE_NEW_FILE
       );
     }
   );
@@ -473,7 +473,7 @@ export async function activate(context: vscode.ExtensionContext) {
     openSimulator,
     runSimulator,
     runDevice,
-    newProject,
+    newFile,
     vscode.debug.registerDebugConfigurationProvider(
       "python",
       simulatorDebugConfiguration


### PR DESCRIPTION
# Description:

In this PR, we are renaming the "New Project" command to "New File" to be more accurate. Also any other areas where "New Project" is used.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# Limitations:

There is the VS Code command "File: New File" which users may get confused with.

# Testing:

- [ ] Make sure command palette command still works and says "New File" instead of "New Project".

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
