### PR TITLE
Add warning about running python code in the extension

### DIFF
--- a/locales/en/out/constants.i18n.json
+++ b/locales/en/out/constants.i18n.json
@@ -1,5 +1,5 @@
 {
-  "dialogResponses.acceptAndRun": "Agree and Run",
+  "dialogResponses.agreeAndRun": "Agree and Run",
   "dialogResponses.acceptPrivacy": "Got it",
   "dialogResponses.cancel": "Cancel",
   "dialogResponses.dontShowAgain": "Don't Show Again",
@@ -30,5 +30,5 @@
   "info.welcomeOutputTab": "Welcome to the Adafruit Simulator output tab !\n\n",
   "label.webviewPanel": "Adafruit CPX",
   "name": "Pacifica Simulator",
-  "warning.acceptAndRun": "By selecting ‘Agree and Run’, you understand the extension executes Python code on your local computer, which may be a potential security risk."
+  "warning.agreeAndRun": "By selecting ‘Agree and Run’, you understand the extension executes Python code on your local computer, which may be a potential security risk."
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -116,7 +116,7 @@ export const CONSTANTS = {
   },
   NAME: localize("name", "Pacifica Simulator"),
   WARNING: {
-    ACCEPT_AND_RUN: localize("warning.acceptAndRun", "By selecting ‘Agree and Run’, you understand the extension executes Python code on your local computer, which may be a potential security risk."),
+    ACCEPT_AND_RUN: localize("warning.agreeAndRun", "By selecting ‘Agree and Run’, you understand the extension executes Python code on your local computer, which may be a potential security risk."),
   }
 };
 
@@ -165,7 +165,7 @@ export enum WebviewMessages {
 // tslint:disable-next-line: no-namespace
 export namespace DialogResponses {
   export const ACCEPT_AND_RUN: MessageItem = {
-    title: localize("dialogResponses.acceptAndRun", "Agree and Run")
+    title: localize("dialogResponses.agreeAndRun", "Agree and Run")
   };
   export const CANCEL: MessageItem = {
     title: localize("dialogResponses.cancel", "Cancel")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -243,12 +243,12 @@ export async function activate(context: vscode.ExtensionContext) {
           DialogResponses.CANCEL
         )
         .then((selection: vscode.MessageItem | undefined) => {
-          let exitCommand = true;
+          let hasAccepted = true;
           if (selection === DialogResponses.ACCEPT_AND_RUN) {
             shouldShowRunCodePopup = false;
-            exitCommand = false;
+            hasAccepted = false;
           }
-          return exitCommand;
+          return hasAccepted;
         });
       // Don't run users code if they don't accept
       if (shouldExitCommand) { return; }


### PR DESCRIPTION
# Description:

This PR adds a warning to the user that the code they are running is being run on their actual computer

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Testing:

- [ ] make sure that running the simulator pops up the notification
- [ ] cancel doesn't run the code
- [ ] accept and run runs code and you never see the notification again

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
