### PR TITLE
Fix bug occuring when value exceed bounds in slider input

### DIFF
--- a/src/view/components/toolbar/InputSlider.tsx
+++ b/src/view/components/toolbar/InputSlider.tsx
@@ -125,8 +125,7 @@ class InputSlider extends React.Component<ISliderProps, any, any> {
     if (valueInt < this.props.minValue) {
       valueInt = this.props.minValue;
       this.setState({ value: valueInt });
-    }
-    if (valueInt > this.props.maxValue) {
+    } else if (valueInt > this.props.maxValue) {
       valueInt = this.props.maxValue;
       this.setState({ value: valueInt });
     }


### PR DESCRIPTION
# Description:

This PR solve the [bug ](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_workitems/edit/32636/) that happens when we type a value that exceed the slider bounds. The new code checks the value before sending it and put it back to the bounds if necessary.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ]  Try using the slider and make sure the right event is fired with the right value.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
