### PR TITLE
Remove show of channel on 'activate'

### DIFF
--- a/src/serialMonitor.ts
+++ b/src/serialMonitor.ts
@@ -57,7 +57,6 @@ export class SerialMonitor implements vscode.Disposable {
     public initialize() {
         const defaultBaudRate: number = SerialMonitor.DEFAULT_BAUD_RATE;
         this._outputChannel = vscode.window.createOutputChannel(CONSTANTS.MISC.SERIAL_MONITOR_NAME);
-        this._outputChannel.show(true);
         this._currentBaudRate = defaultBaudRate;
         this._portsStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, STATUS_BAR_PRIORITY.PORT);
         this._portsStatusBar.command = "pacifica.selectSerialPort";


### PR DESCRIPTION
# Description:

Simple fix to remove the displaying of the Serial Monitor Channel when the extension is activated. One example of this problem is when the user simply clicks "Deploy to Device", the serial monitor channel shows when it should have no part in it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

None

# Testing:

- [ ] Try to load the extension and then click "Deploy to Device" with a code file already present. The Serial Monitor Channel should no longer be opened.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules