### PR TITLE
Fix lack of null check on currentActiveFile

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -742,7 +742,7 @@ const updateCurrentFileIfPython = async (
     setPathAndSendMessage(currentPanel,
       getActivePythonFile() || "");
   }
-  if (utils.getActiveEditorFromPath(currentTextDocument.fileName) === undefined) {
+  if (currentTextDocument && utils.getActiveEditorFromPath(currentTextDocument.fileName) === undefined) {
     await vscode.window.showTextDocument(currentTextDocument, vscode.ViewColumn.One);
   }
 };


### PR DESCRIPTION
# Description:

This PR is a bug fix for if you try to run no file

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# Testing:

- [ ] open the simulator with no files open and press play, should not blow up

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
