### PR TITLE
Update test message for serial monitor

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,10 @@ export const CONSTANTS = {
       "error.noPythonPath",
       "We found that you don't have Python 3 installed on your computer, please install the latest version, add it to your PATH and try again."
     ),
+    RECONNECT_DEVICE: localize(
+      "error.reconnectDevice",
+      "Please disconnect your Circuit Playground Express and try again."
+    ),
     STDERR: (data: string) => {
       return localize("error.stderr", `\n[ERROR] ${data} \n`);
     },

--- a/src/serialPortControl.ts
+++ b/src/serialPortControl.ts
@@ -76,6 +76,7 @@ export class SerialPortControl {
                     this._currentSerialPort.write(CONSTANTS.MISC.SERIAL_MONITOR_TEST_IF_OPEN, "Both NL & CR", (err: any) => {
                         if (err && !(err.message.indexOf(CONSTANTS.ERROR.COMPORT_UNKNOWN_ERROR) >= 0)) {
                             logToOutputChannel(this._outputChannel, CONSTANTS.ERROR.FAILED_TO_OPEN_SERIAL_PORT(this._currentPort));
+                            logToOutputChannel(this._outputChannel, CONSTANTS.ERROR.RECONNECT_DEVICE);
                             reject(err);
                         } else {
                             logToOutputChannel(this._outputChannel, CONSTANTS.INFO.OPENED_SERIAL_PORT(this._currentPort));


### PR DESCRIPTION
# Description:

In this PR, I'm updating the message we're sending to test if the serial port is open. Previously, the message wasn't informative enough to the user.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

None

# Testing:

Can't really reliably test this since we only see the message if the serial port errors out.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
