### PR TITLE
Persist user's choice for "Don't Show Again" for "New File" command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,9 +237,9 @@ export async function activate(context: vscode.ExtensionContext) {
     const fileName = "template.py";
     const filePath = __dirname + path.sep + fileName;
     const file = fs.readFileSync(filePath, "utf8");
-    const shouldShowNewFile: boolean = context.globalState.get("shouldShowNewFile", true);
+    const shouldShowNewFilePopup: boolean = context.globalState.get("shouldShowNewFilePopup", true);
 
-    if (shouldShowNewFile) {
+    if (shouldShowNewFilePopup) {
       vscode.window
         .showInformationMessage(
           CONSTANTS.INFO.NEW_FILE,
@@ -249,7 +249,7 @@ export async function activate(context: vscode.ExtensionContext) {
         )
         .then((selection: vscode.MessageItem | undefined) => {
           if (selection === DialogResponses.DONT_SHOW) {
-            context.globalState.update("shouldShowNewFile", false);
+            context.globalState.update("shouldShowNewFilePopup", false);
             telemetryAI.trackFeatureUsage(
               TelemetryEventName.CLICK_DIALOG_DONT_SHOW
             );
@@ -270,7 +270,6 @@ export async function activate(context: vscode.ExtensionContext) {
         });
     }
 
-    context.globalState.update("shouldShowNewFile", true);
     // tslint:disable-next-line: ban-comma-operator
     vscode.workspace
       .openTextDocument({ content: file, language: "python" })


### PR DESCRIPTION
# Description:

In this PR, we are saving the user's choice as part of the extension's `globalState`. What this means is that the InformationMessage (i.e. the pop-up on the bottom right) will not show again after the user clicks "Don't Show Again" and re-opens VS Code. Previously, if they selected "Don't Show Again" and then re-opened VS Code, they would get the same pop up again. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Limitations:

None

# Testing:

- [ ] Try to click "Don't Show Again" and then use the "New File" command. You should not see the pop-up any more. After closing and reloading the Extension Development Host, run the "New File" command. You should still not see pop-up (which means the setting was persisted in the extension's `globalState`).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules