### PR TITLE
Users/t anmah/simulation dependency checker fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,15 @@ You will be prompted to install the Python dependencies during the first use.
 - _**[Python 3.7.4](https://www.python.org/downloads/)**_: Make sure you've added python and pip to your PATH in your environment variables. (1)
 - _**[Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)**_: This will be installed automatically from the marketplace when you install Device Simulator Express.
 
-The following dependecies can be installed for you by the extension by clicking yes when you are prompted to (**except** `pywin32` which is needed only on Windows platform). (2)
+- Python Modules
+  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following Python modules should be downloaded when you select "yes" on prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
+    - Playsound : `pip install playsound`
+    - Pywin32 : `pip install pywin32`
+      - **Note:** This is only needed for Windows computers.
+    - Python-Socketio : `pip install python-socketio`
+    - Requests : `pip install requests`
+    - Application Insights: `pip install applicationinsights`
 
-- _**Playsound**_  
-  install by typing the following commands in a console: `pip install playsound`
-
-- _**Pywin 32**_  
-  install by typing the following commands in a console (only for Windows computers, you must run it manually): `pip install pywin32`
-- _**Python-Socketio**_  
-   install by typing the following commands in a console: `pip install python-socketio`
-- _**Requests**_  
-   install by typing the following commands in a console: `pip install requests`
-- _**Application Insights**_  
-  install by typing the following commands in a console: `pip install applicationinsights`
 
 ## Useful Links
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,11 @@ You will be prompted to install the Python dependencies during the first use.
 - _**[Python 3.7.4](https://www.python.org/downloads/)**_: Make sure you've added python and pip to your PATH in your environment variables. (1)
 - _**[Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)**_: This will be installed automatically from the marketplace when you install Device Simulator Express.
 
-- Python Modules for Deploying to Device
-    - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
-
 - Python Modules for Simulation
   - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following Python modules should be downloaded when you select "yes" on the prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
     - Playsound : `pip install playsound`
     - Pywin32 : `pip install pywin32`
-      - **Note:** This is only needed for Windows computers.
+      - On Windows, you need to use the above command in the console to manually install pywin32.
     - Python-Socketio : `pip install python-socketio`
     - Requests : `pip install requests`
     - Application Insights: `pip install applicationinsights`
@@ -100,6 +97,8 @@ Before deploying the python code to your CPX device, you need to format your dev
 1. Download the firmware with the .uf2 file (link: https://learn.adafruit.com/adafruit-circuit-playground-express/circuitpython-quickstart)
 2. Download the lastest version of the cpx library (link: https://learn.adafruit.com/welcome-to-circuitpython/circuitpython-libraries).  
    **_Note:_** Make sure you name your file main.py or code.py: the device automatically runs the first file that is likely named.
+
+Then, if you are on Windows, you will also need to install the Python Pywin32 package. Use the following command in the console: `pip install pywin32`
 
 !["Deploy to Device" example](https://www.microsoft.com/en-us/garage/wp-content/uploads/sites/5/2019/08/deployToBoard.png)
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ You will be prompted to install the Python dependencies during the first use.
 - _**[Python 3.7.4](https://www.python.org/downloads/)**_: Make sure you've added python and pip to your PATH in your environment variables. (1)
 - _**[Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)**_: This will be installed automatically from the marketplace when you install Device Simulator Express.
 
-- Python Modules for Deploy to Device
+- Python Modules for Deploying to Device
     - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
 
 - Python Modules for Simulation
-  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following Python modules should be downloaded when you select "yes" on prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
+  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following Python modules should be downloaded when you select "yes" on the prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
     - Playsound : `pip install playsound`
     - Pywin32 : `pip install pywin32`
       - **Note:** This is only needed for Windows computers.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ You will be prompted to install the Python dependencies during the first use.
 - _**[Python 3.7.4](https://www.python.org/downloads/)**_: Make sure you've added python and pip to your PATH in your environment variables. (1)
 - _**[Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)**_: This will be installed automatically from the marketplace when you install Device Simulator Express.
 
-- Python Modules
+- Python Modules for Deploy to Device
+    - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
+
+- Python Modules for Simulation
   - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following Python modules should be downloaded when you select "yes" on prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
     - Playsound : `pip install playsound`
     - Pywin32 : `pip install pywin32`

--- a/docs/developers-setup.md
+++ b/docs/developers-setup.md
@@ -14,7 +14,10 @@
   (for example it could be found at : `c:\users\<...>\appdata\local\programs\python\python37\lib\site-packages\pip`)
 - Run in a console `python -m pip install --upgrade pip`
 
-* Python Modules
+* Python Modules for Deploy to Device
+    - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
+    
+* Python Modules for Simulation
   - **Note:** On extension activation, you will be prompted with a popup asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on prompt message.
     - playsound
     - pytest

--- a/docs/developers-setup.md
+++ b/docs/developers-setup.md
@@ -13,19 +13,18 @@
 - **NOTE :** Make sure pip is added to your environment variables as well
   (for example it could be found at : `c:\users\<...>\appdata\local\programs\python\python37\lib\site-packages\pip`)
 - Run in a console `python -m pip install --upgrade pip`
-
-* Python Modules for Deploying to Device
-    - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
     
-* Python Modules for Simulation
+* Python Modules
   - **Note:** On extension activation, you will be prompted with a popup asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on the prompt message.
-    - playsound
-    - pytest
-    - python-socketio
-    - requests
-    - applicationinsights
     - pywin32 **(on Windows only)**
+        - On Windows, you need to use the following command in the console to manually install pywin32: `pip install pywin32`
+    - *playsound*
+    - *pytest*
+    - *python-socketio*
+    - *requests*
+    - *applicationinsights*
 
+    *italics*: used in simulation mode only
 * VS Code
 
 * Python extension for VS Code (download from VS Code market place)

--- a/docs/developers-setup.md
+++ b/docs/developers-setup.md
@@ -14,11 +14,11 @@
   (for example it could be found at : `c:\users\<...>\appdata\local\programs\python\python37\lib\site-packages\pip`)
 - Run in a console `python -m pip install --upgrade pip`
 
-* Python Modules for Deploy to Device
+* Python Modules for Deploying to Device
     - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
     
 * Python Modules for Simulation
-  - **Note:** On extension activation, you will be prompted with a popup asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on prompt message.
+  - **Note:** On extension activation, you will be prompted with a popup asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on the prompt message.
     - playsound
     - pytest
     - python-socketio

--- a/docs/developers-setup.md
+++ b/docs/developers-setup.md
@@ -15,21 +15,13 @@
 - Run in a console `python -m pip install --upgrade pip`
 
 * Python Modules
-
-  - **Note:** On extension activation you will be prompted a popup asking if you want the modules to be automatically installed for you, **except** `pywin32` which is needed only on Windows platform.
-  - Playsound
-    - Run the command in a console : `pip install playsound`
-  - pytest
-    - Run the command in a console : `pip install pytest`
-  - Pywin32
-    - **Note:** This is only needed for Windows computers. You must install it manually with the above command!
-    - Run the command in a console : `pip install pywin32`
-  - Python-Socketio
-    - Run the command in a console : `pip install python-socketio`
-  - Requests
-    - Run the command in a console : `pip install requests`
-  - Application Insights
-    - Run the command in a console : `pip install applicationinsights`
+  - **Note:** On extension activation, you will be prompted with a popup asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on prompt message.
+    - playsound
+    - pytest
+    - python-socketio
+    - requests
+    - applicationinsights
+    - pywin32 **(on Windows only)**
 
 * VS Code
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,11 @@ _Note: You need to install all the dependencies in order to use the extension._
     _(Note: the easiest way to do it might be when you install Python, you can select the "Add to PATH" option directly. Otherwise you can search how to insert it manually, but make sure that when you type `python` (or `python3.7`) in a terminal, the command is recognized.)_
 - [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
   - **Note:** This extension is installed automatically from the marketplace when you install our extension
-- Python Modules
+
+- Python Modules for Deploy to Device
+    - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
+
+- Python Modules for Simulation
   - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
     - Playsound : `pip install playsound`
     - Pywin32 : `pip install pywin32`

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,13 +23,13 @@ _Note: You need to install all the dependencies in order to use the extension._
 - [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
   - **Note:** This extension is installed automatically from the marketplace when you install our extension
 - Python Modules
-  - **Note:** On extension activation you will be prompted a popup asking if you want the modules to be automatically installed for you, **except** `pywin32` which is needed only on Windows platform.
-  - Playsound : `pip install playsound`
-  - Pywin32 : `pip install pywin32`
-    - **Note:** This is only needed for Windows computers. You must install it manually with the above command!
-  - Python-Socketio : `pip install python-socketio`
-  - Requests : `pip install requests`
-  - Application Insights: `pip install applicationinsights`
+  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
+    - Playsound : `pip install playsound`
+    - Pywin32 : `pip install pywin32`
+      - **Note:** This is only needed for Windows computers.
+    - Python-Socketio : `pip install python-socketio`
+    - Requests : `pip install requests`
+    - Application Insights: `pip install applicationinsights`
 
 ## How to use the Extension
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,19 +22,18 @@ _Note: You need to install all the dependencies in order to use the extension._
     _(Note: the easiest way to do it might be when you install Python, you can select the "Add to PATH" option directly. Otherwise you can search how to insert it manually, but make sure that when you type `python` (or `python3.7`) in a terminal, the command is recognized.)_
 - [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
   - **Note:** This extension is installed automatically from the marketplace when you install our extension
+  
+* Python Modules
+  - **Note:** On extension activation, you will be prompted with a popup asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on the prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
+    - pywin32 **(on Windows only)**: `pip install pywin32`
+        - On Windows, you need to use the above command in the console to manually install pywin32.
+    - *playsound*: `pip install playsound`
+    - *pytest*: `pip install pytest`
+    - *python-socketio*: `pip install python-socketio`
+    - *requests*: `pip install requests`
+    - *applicationinsights*: `pip install applicationinsights`
 
-- Python Modules for Deploying to Device
-    - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
-
-- Python Modules for Simulation
-  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on the prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
-    - Playsound : `pip install playsound`
-    - Pywin32 : `pip install pywin32`
-      - **Note:** This is only needed for Windows computers.
-    - Python-Socketio : `pip install python-socketio`
-    - Requests : `pip install requests`
-    - Application Insights: `pip install applicationinsights`
-
+    *italics*: used in simulation mode only
 ## How to use the Extension
 
 - [How to use the Extension](/docs/how-to-use.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,11 +23,11 @@ _Note: You need to install all the dependencies in order to use the extension._
 - [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
   - **Note:** This extension is installed automatically from the marketplace when you install our extension
 
-- Python Modules for Deploy to Device
+- Python Modules for Deploying to Device
     - If you're on Windows, use the following command in the console to install pywin32: `pip install pywin32`
 
 - Python Modules for Simulation
-  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
+  - **Note:** On extension activation, you will be prompted with a popup message asking if you want the modules to be automatically installed for you. The following python modules should be downloaded when you select "yes" on the prompt message. **If modules are not installed correctly, please use the "pip install" commands listed below.**
     - Playsound : `pip install playsound`
     - Pywin32 : `pip install pywin32`
       - **Note:** This is only needed for Windows computers.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ const languages = [{ folderName: "en", id: "en" }];
 gulp.task("clean", () => {
   return del(
     [
-      "out/!(python_libs)",
+      "out/*",
       "package.nls.*.json",
       "../../dist/*0.0.0-UNTRACKEDVERSION.vsix"
     ],
@@ -37,7 +37,6 @@ const pythonToMove = [
   "./src/adafruit_circuitplayground/*.*",
   "./src/*.py",
   "./src/requirements.txt",
-  "./src/requirements-windows.txt"
 ];
 
 gulp.task("python-compile", () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,8 @@ gulp.task("clean", () => {
 const pythonToMove = [
   "./src/adafruit_circuitplayground/*.*",
   "./src/*.py",
-  "./src/requirements.txt"
+  "./src/requirements.txt",
+  "./src/requirements-windows.txt"
 ];
 
 gulp.task("python-compile", () => {

--- a/locales/en/out/constants.i18n.json
+++ b/locales/en/out/constants.i18n.json
@@ -9,6 +9,7 @@
   "dialogResponses.installNow": "Install Now",
   "dialogResponses.dontInstall": "Don't Install",
   "dialogResponses.tutorials": "Tutorials on Adafruit",
+  "dialogResponses.readInstall": "Read installation docs",
   "error.debuggerServerInitFailed": "Warning : The Debugger Server cannot be opened. Please try to free the port {0} if it's already in use or select another one in your Settings 'Device Simulator Express: Debugger Server Port' and start another debug session.\n You can still debug your code but you won't be able to use the Simulator.",
   "error.debuggingSessionInProgress": "[ERROR] A debugging session is currently in progress, please stop it before running your code. \n",
   "error.incorrectFileNameForDevice": "[ERROR] Can\\'t deploy to your Circuit Playground Express device, please rename your file to \"code.py\" or \"main.py\". \n",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,7 @@ export const CONSTANTS = {
       "[ERROR] A debugging session is currently in progress, please stop it before running your code. \n"
     ),
     DEPENDENCY_DOWNLOAD_ERROR:
-      "Package downloads failed. Some functionality may not work. Try restarting the simulator or review the installation docs.",
+      "Package downloads failed. Some functionalities may not work. Try restarting the simulator or review the installation docs.",
     FAILED_TO_OPEN_SERIAL_PORT: (port: string): string => {
       return localize(
         "error.failedToOpenSerialPort",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,8 @@ export const CONSTANTS = {
       "error.debuggingSessionInProgress",
       "[ERROR] A debugging session is currently in progress, please stop it before running your code. \n"
     ),
+    DEPENDENCY_DOWNLOAD_ERROR:
+      "Package downloads failed. Some functionality may not work. ",
     FAILED_TO_OPEN_SERIAL_PORT: (port: string): string => {
       return localize(
         "error.failedToOpenSerialPort",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,7 @@ export const CONSTANTS = {
       "[ERROR] A debugging session is currently in progress, please stop it before running your code. \n"
     ),
     DEPENDENCY_DOWNLOAD_ERROR:
-      "Package downloads failed. Some functionality may not work. ",
+      "Package downloads failed. Some functionality may not work. Try restarting the simulator or review the installation docs.",
     FAILED_TO_OPEN_SERIAL_PORT: (port: string): string => {
       return localize(
         "error.failedToOpenSerialPort",
@@ -102,6 +102,10 @@ export const CONSTANTS = {
       "error.unexpectedMessage",
       "Webview sent an unexpected message"
     )
+  },
+  FILESYSTEM: {
+    OUTPUT_DIRECTORY: "out",
+    PYTHON_LIBS_DIR: "python_libs"
   },
   INFO: {
     ARE_YOU_SURE: localize(
@@ -205,6 +209,7 @@ export const CONSTANTS = {
       "https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/tree/master/examples",
     HELP:
       "https://learn.adafruit.com/adafruit-circuit-playground-express/circuitpython-quickstart",
+    INSTALL: "https://github.com/microsoft/vscode-python-devicesimulator/blob/dev/docs/install.md",
     PRIVACY: "https://www.adafruit.com/privacy",
     TUTORIALS:
       "https://learn.adafruit.com/circuitpython-made-easy-on-circuit-playground-express/circuit-playground-express-library"
@@ -360,6 +365,9 @@ export namespace DialogResponses {
   };
   export const YES: MessageItem = {
     title: localize("dialogResponses.Yes", "Yes")
+  };
+  export const READ_INSTALL_MD: MessageItem = {
+    title: localize("dialogResponses.readInstall", "Read installation docs")
   };
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,7 @@ export async function activate(context: vscode.ExtensionContext) {
         {
           // Only allow the webview to access resources in our extension's media directory
           localResourceRoots: [
-            vscode.Uri.file(path.join(context.extensionPath, "out"))
+            vscode.Uri.file(path.join(context.extensionPath, CONSTANTS.FILESYSTEM.OUTPUT_DIRECTORY))
           ],
           enableScripts: true
         }
@@ -412,7 +412,7 @@ export async function activate(context: vscode.ExtensionContext) {
       currentPanel.webview.postMessage({ command: "activate-play" });
 
       childProcess = cp.spawn(pythonExecutableName, [
-        utils.getPathToScript(context, "out", "process_user_code.py"),
+        utils.getPathToScript(context, CONSTANTS.FILESYSTEM.OUTPUT_DIRECTORY, "process_user_code.py"),
         currentFileAbsPath,
         JSON.stringify({ enable_telemetry: utils.getTelemetryState() })
       ]);
@@ -549,7 +549,7 @@ export async function activate(context: vscode.ExtensionContext) {
       );
 
       const deviceProcess = cp.spawn(pythonExecutableName, [
-        utils.getPathToScript(context, "out", "device.py"),
+        utils.getPathToScript(context, CONSTANTS.FILESYSTEM.OUTPUT_DIRECTORY, "device.py"),
         currentFileAbsPath
       ]);
 

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -310,7 +310,7 @@ export const installPythonDependencies = async (context: vscode.ExtensionContext
 
     // run command to download dependencies to out/python_libs
     const { stdout } = await exec(`${pythonExecutable} -m pip install -r ${requirementsPath} -t ${pathToLibs}`);
-    console.log(stdout);
+    console.info(stdout);
     installed = true;
     
     vscode.window.showInformationMessage(CONSTANTS.INFO.SUCCESSFUL_INSTALL);

--- a/src/requirements-windows.txt
+++ b/src/requirements-windows.txt
@@ -1,6 +1,0 @@
-playsound==1.2.2
-pytest==5.0.1
-applicationinsights==0.11.9
-python-socketio==4.3.1
-requests==2.22.0
-pywin32>=224

--- a/src/requirements-windows.txt
+++ b/src/requirements-windows.txt
@@ -3,3 +3,4 @@ pytest==5.0.1
 applicationinsights==0.11.9
 python-socketio==4.3.1
 requests==2.22.0
+pywin32>=224

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,4 @@ pytest==5.0.1
 applicationinsights==0.11.9
 python-socketio==4.3.1
 requests==2.22.0
+pywin32==227; platform_system == "Windows"


### PR DESCRIPTION
# Description:

Fixed automated package installer for Python libraries needed for custom adafruit_circuitplayground.express library. 
 - Fixed pywin32 requirements version for Python 3.8
 - Improved error handling for Python package installation; used to fail silently, but now pops up with an error message. 
 - More robust way of checking whether package installation failed; now checks for presence of ./out/python_libs to see if installation failed.
 - improved README + etc. docs for new dependency workflow (no more need to pip install packages globally).

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

Sound functionality still fails on Mac OS. Issue already recorded on backlog item 28661. 

# Testing:

- [ ] Manual testing (test with/without dependencies installed prior, test with bad requirements.txt, tested on Mac OS, and Windows.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
