### PR TITLE
changed package import name from cpx to cp

### DIFF
--- a/src/adafruit_circuitplayground/__init__.py
+++ b/src/adafruit_circuitplayground/__init__.py
@@ -1,1 +1,4 @@
+# added compatibility for new import structure in CircuitPython
+# https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/pull/79 
+
 from .express import cpx as cp

--- a/src/adafruit_circuitplayground/__init__.py
+++ b/src/adafruit_circuitplayground/__init__.py
@@ -1,0 +1,1 @@
+from .express import cpx as cp

--- a/src/template.py
+++ b/src/template.py
@@ -8,7 +8,7 @@ https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/tree/master
 """
 
 # import CPX library
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
     # start your code here


### PR DESCRIPTION
# Description:

Allowed for both imports as:
`from adafruit_circuitplayground import cp`
and
`from adafruit_circuitplayground.express import cpx`

This was requested since the first import statement above is how most tutorials present the import statement. 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Limitations:


# Testing:

- [ ] Test with simulation and deploy to board

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
