### PR TITLE
Users/t anmah/pylint import error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ A `ThirdPartyNotices.txt` file is provided in the extension's source code listin
 - The first time you install the extension, you'll need to execute the `run` command at least once in order to access auto-completion.
 - While running a code file, if you get an error saying it can't find the file, make sure you've clicked on a valid Python code file before running it.
 - To open the output panel again after closing it go to VS Code menu: `View->Output`.
-- If you have pylint enabled, it might underline the import of the adafruit_circuitplayground library, but it will work correctly.
 - If you try to deploy to the device while it's plugged in but you still get an error saying it cannot find the board, make sure your Circuit Playground Express is formatted correctly and that its name matches `CIRCUITPY`.
 - If you can't get the Simulator communication working while debugging, try to open your `Settings` and check the port used under `"Device Simulator Express: Debugger Server Port"`. You can either change it (usually ports above 5000 should work) or try to free it, then start debugging again.
 - When you are using the serial monitor, if you get some unusual error messages, unplug the device and reload the VS Code windows.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -82,7 +82,6 @@ Here are the settings you can change in the Device Simulator Express configurati
 - The first time you install the extension, you'll need to execute the `run` command at least once in order to access auto-completion.
 - While running a code file, if you get an error saying it can't find the file, make sure you've clicked on a valid Python code file before running it.
 - To open the output panel again after closing it go to VS Code menu : `View->Output`.
-- If you have pylint enabled, it might underline the import of the adafruit_circuitplayground library, but it will work correctly.
 - If you try to deploy to the device while it's plugged in but you still get an error saying it cannot find the board, make sure your Circuit Playground Express is formatted correctly and that its name matches `CIRCUITPY`.
 - If you can't get the Simulator communication working while debugging, try to open you `Settings` and check the port used under `'Device Simulator Express: Debugger Server Port'`. You can either change it (usually ports above 5000 could work) or try to free it, then start debugging again.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,6 +67,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Add our library path to settings.json for autocomplete functionality
   updatePythonExtraPaths();
+  
+  // ignore import errors so that adafruit_circuitpython library
+  // doesn't trigger lint errors
+  updatePylintArgs();
 
   pythonExecutableName = await utils.setPythonExectuableName();
 
@@ -880,21 +884,30 @@ const checkForTelemetry = (sensorState: any) => {
 };
 
 const updatePythonExtraPaths = () => {
-  const pathToLib: string = __dirname;
-  const currentExtraPaths: string[] =
-    vscode.workspace.getConfiguration().get("python.autoComplete.extraPaths") ||
-    [];
-  if (!currentExtraPaths.includes(pathToLib)) {
-    currentExtraPaths.push(pathToLib);
+  updateConfigLists("python.autoComplete.extraPaths",[__dirname], vscode.ConfigurationTarget.Global)
+};
+
+const updatePylintArgs = () => {
+  updateConfigLists("python.linting.pylintArgs",["--disable=E0401"], vscode.ConfigurationTarget.Workspace)
+}
+
+const updateConfigLists = (section: string, newItems: string[], scope: vscode.ConfigurationTarget) => {
+  // function for adding elements to configuration arrays
+  const currentExtraItems: string[] = vscode.workspace.getConfiguration().get(section) || [];
+
+  for (const item of newItems) {
+    if (!currentExtraItems.includes(item)) {
+      currentExtraItems.push(item);
+    }
   }
   vscode.workspace
     .getConfiguration()
     .update(
-      "python.autoComplete.extraPaths",
-      currentExtraPaths,
-      vscode.ConfigurationTarget.Global
+      section,
+      currentExtraItems,
+      scope
     );
-};
+}
 
 function getWebviewContent(context: vscode.ExtensionContext) {
   return `<!DOCTYPE html>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Add our library path to settings.json for autocomplete functionality
   updatePythonExtraPaths();
   
-  // ignore import errors so that adafruit_circuitpython library
+  // ignore import errors so that adafruit_circuitplayground library
   // doesn't trigger lint errors
   updatePylintArgs();
 


### PR DESCRIPTION
# Description:

Making sure that pylint doesn't flag the adafruit_circuitplayground library import as not found. This is done by suppressing the import-error in pylint for the workspace. Since pylint is often used in vscode (and users of the Python library are prompted to install it), we believed that this would be worth it.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

Configuration is not updated until extension is opened for the first time (after compilation) 

# Testing:
- [ ] Testing with/without existing configurations in settings.json

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
