### PR TITLE
re-worked first-time dependency install

### DIFF
--- a/locales/en/package.i18n.json
+++ b/locales/en/package.i18n.json
@@ -1,6 +1,7 @@
 {
   "deviceSimulatorExpressExtension.commands.changeBaudRate": "Change Baud Rate",
   "deviceSimulatorExpressExtension.commands.closeSerialMonitor": "Close Serial Monitor",
+  "deviceSimulatorExpressExtension.commands.installDependencies": "Install Extension Dependencies",
   "deviceSimulatorExpressExtension.commands.label": "Device Simulator Express",
   "deviceSimulatorExpressExtension.commands.openSerialMonitor": "Open Serial Monitor",
   "deviceSimulatorExpressExtension.commands.openSimulator": "Open Simulator",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "Adafruit"
     ],
     "activationEvents": [
+        "onCommand:deviceSimulatorExpress.installDependencies",
         "onCommand:deviceSimulatorExpress.openSerialMonitor",
         "onCommand:deviceSimulatorExpress.openSimulator",
         "onCommand:deviceSimulatorExpress.runSimulator",
@@ -51,8 +52,13 @@
                 "category": "%deviceSimulatorExpressExtension.commands.label%"
             },
             {
-                "command": "deviceSimulatorExpress.openSerialMonitor",
-                "title": "%deviceSimulatorExpressExtension.commands.openSerialMonitor%",
+                "command": "deviceSimulatorExpress.closeSerialMonitor",
+                "title": "%deviceSimulatorExpressExtension.commands.closeSerialMonitor%",
+                "category": "%deviceSimulatorExpressExtension.commands.label%"
+            },
+            {
+                "command": "deviceSimulatorExpress.installDependencies",
+                "title": "%deviceSimulatorExpressExtension.commands.installDependencies%",
                 "category": "%deviceSimulatorExpressExtension.commands.label%"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,7 @@
 {
   "deviceSimulatorExpressExtension.commands.changeBaudRate": "Change Baud Rate",
   "deviceSimulatorExpressExtension.commands.closeSerialMonitor": "Close Serial Monitor",
+  "deviceSimulatorExpressExtension.commands.installDependencies": "Install Extension Dependencies",
   "deviceSimulatorExpressExtension.commands.label": "Device Simulator Express",
   "deviceSimulatorExpressExtension.commands.openSerialMonitor": "Open Serial Monitor",
   "deviceSimulatorExpressExtension.commands.openSimulator": "Open Simulator",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,7 +114,7 @@ export const CONSTANTS = {
     INFO: {
         ARE_YOU_SURE: localize(
             "info.areYouSure",
-            "Are you sure you don't want to install the dependencies? The extension can't run without installing it."
+            "Are you sure you don't want to install the dependencies? The extension can't run without installing them."
         ),
         CLOSED_SERIAL_PORT: (port: string) => {
             return localize(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,7 +114,7 @@ export const CONSTANTS = {
     INFO: {
         ARE_YOU_SURE: localize(
             "info.areYouSure",
-            "Are you sure you don't want to install the dependencies? The extension can't run without installing it"
+            "Are you sure you don't want to install the dependencies? The extension can't run without installing it."
         ),
         CLOSED_SERIAL_PORT: (port: string) => {
             return localize(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -355,6 +355,22 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     );
 
+    const installDependencies: vscode.Disposable = vscode.commands.registerCommand(
+        "deviceSimulatorExpress.installDependencies",
+        () => {
+            const pathToLibs: string = utils.getPathToScript(
+                context,
+                CONSTANTS.FILESYSTEM.OUTPUT_DIRECTORY,
+                CONSTANTS.FILESYSTEM.PYTHON_LIBS_DIR
+            );
+            return utils.installPythonDependencies(
+                context,
+                pythonExecutableName,
+                pathToLibs
+            );
+        }
+    );
+
     const killProcessIfRunning = () => {
         if (childProcess !== undefined) {
             if (currentPanel) {
@@ -910,6 +926,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         changeBaudRate,
         closeSerialMonitor,
+        installDependencies,
         openSerialMonitor,
         openSimulator,
         newFile,

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -77,7 +77,7 @@ export function tryParseJSON(jsonString: string): any | boolean {
         if (jsonObj && typeof jsonObj === "object") {
             return jsonObj;
         }
-    } catch (exception) { }
+    } catch (exception) {}
 
     return false;
 }

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -294,6 +294,7 @@ export const promptInstallPythonDependencies = (
     return vscode.window
         .showInformationMessage(
             CONSTANTS.INFO.INSTALL_PYTHON_DEPENDENCIES,
+            { modal: true },
             DialogResponses.YES,
             DialogResponses.NO
         )
@@ -304,10 +305,11 @@ export const promptInstallPythonDependencies = (
                     pythonExecutable,
                     pathToLibs
                 );
-            } else if (selection === DialogResponses.NO) {
+            } else {
                 return vscode.window
                     .showInformationMessage(
                         CONSTANTS.INFO.ARE_YOU_SURE,
+                        { modal: true },
                         DialogResponses.INSTALL_NOW,
                         DialogResponses.DONT_INSTALL
                     )

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -77,7 +77,7 @@ export function tryParseJSON(jsonString: string): any | boolean {
         if (jsonObj && typeof jsonObj === "object") {
             return jsonObj;
         }
-    } catch (exception) {}
+    } catch (exception) { }
 
     return false;
 }
@@ -294,7 +294,6 @@ export const promptInstallPythonDependencies = (
     return vscode.window
         .showInformationMessage(
             CONSTANTS.INFO.INSTALL_PYTHON_DEPENDENCIES,
-            { modal: true },
             DialogResponses.YES,
             DialogResponses.NO
         )
@@ -309,7 +308,6 @@ export const promptInstallPythonDependencies = (
                 return vscode.window
                     .showInformationMessage(
                         CONSTANTS.INFO.ARE_YOU_SURE,
-                        { modal: true },
                         DialogResponses.INSTALL_NOW,
                         DialogResponses.DONT_INSTALL
                     )


### PR DESCRIPTION
# Description:

Dependency install pop-up is now harder to ignore upon first install, reducing the chance that users accidentally skip out on dependency install. There is also now an option to install dependencies in the ctrl+shift+p menu, in case users deny downloading dependencies the first time.

NOTE: if you want to disable the dependency prompt because you have the pip packages installed globally, the option is available in settings (from before)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Limitations:

# Testing:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
