### PR TITLE
More Venv Fixes + Dependency Fail Detect on Python

### DIFF
--- a/src/check_python_dependencies.py
+++ b/src/check_python_dependencies.py
@@ -1,10 +1,20 @@
 # from https://stackoverflow.com/questions/16294819/check-if-my-python-has-all-required-packages
 import sys
 import pkg_resources
+import python_constants as CONSTANTS
 
-with open(f"{sys.path[0]}/requirements.txt") as f:
-    dependencies = [x.strip() for x in f.readlines()]
 
-# here, if a dependency is not met, a DistributionNotFound or VersionConflict
-# exception is thrown.
-pkg_resources.require(dependencies)
+def check_for_dependencies():
+    with open(f"{sys.path[0]}/requirements.txt") as f:
+        dependencies = [x.strip() for x in f.readlines()]
+
+    # here, if a dependency is not met, a DistributionNotFound or VersionConflict
+    # exception is caught and replaced with a new exception with a clearer description.
+    try:
+        pkg_resources.require(dependencies)
+    except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict) as e:
+        raise Exception(CONSTANTS.DEPEND_ERR)
+
+
+if __name__ == "__main__":
+    check_for_dependencies()

--- a/src/debug_user_code.py
+++ b/src/debug_user_code.py
@@ -6,7 +6,10 @@ import sys
 import traceback
 from pathlib import Path
 import python_constants as CONSTANTS
+import check_python_dependencies
 
+# will propagate errors if dependencies aren't sufficient
+check_python_dependencies.check_for_dependencies()
 
 # Insert absolute path to Adafruit library into sys.path
 abs_path_to_parent_dir = os.path.dirname(os.path.abspath(__file__))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -441,8 +441,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const installDependencies: vscode.Disposable = vscode.commands.registerCommand(
         "deviceSimulatorExpress.common.installDependencies",
-        () => {
-            utils.setupEnv(context, true);
+        async () => {
+            pythonExecutableName = await utils.setupEnv(context, true);
             telemetryAI.trackFeatureUsage(
                 TelemetryEventName.COMMAND_INSTALL_EXTENSION_DEPENDENCIES
             );
@@ -1027,11 +1027,13 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    const configsChanged = vscode.workspace.onDidChangeConfiguration(() => {
-        if (utils.checkConfig(CONFIG.CONFIG_ENV_ON_SWITCH)) {
-            utils.setupEnv(context);
+    const configsChanged = vscode.workspace.onDidChangeConfiguration(
+        async () => {
+            if (utils.checkConfig(CONFIG.CONFIG_ENV_ON_SWITCH)) {
+                pythonExecutableName = await utils.setupEnv(context);
+            }
         }
-    });
+    );
 
     context.subscriptions.push(
         installDependencies,

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -546,9 +546,9 @@ export const setupEnv = async (
     let pythonExecutableName = originalPythonExecutableName;
 
     if (!(await areDependenciesInstalled(context, pythonExecutableName))) {
-        const pythonExecutableNameVenv = await getPythonVenv(context);
         // environment needs to install dependencies
         if (!(await checkIfVenv(context, pythonExecutableName))) {
+            const pythonExecutableNameVenv = await getPythonVenv(context);
             if (await hasVenv(context)) {
                 // venv in extention exists with wrong dependencies
                 if (
@@ -562,6 +562,8 @@ export const setupEnv = async (
                         pythonExecutableNameVenv,
                         pythonExecutableName
                     );
+                } else {
+                    pythonExecutableName = pythonExecutableNameVenv;
                 }
             } else {
                 pythonExecutableName = await promptInstallVenv(
@@ -569,15 +571,17 @@ export const setupEnv = async (
                     originalPythonExecutableName
                 );
             }
+
+            if (pythonExecutableName === pythonExecutableNameVenv) {
+                vscode.window.showInformationMessage(
+                    CONSTANTS.INFO.UPDATED_TO_EXTENSION_VENV
+                );
+                vscode.workspace
+                    .getConfiguration()
+                    .update(CONFIG.PYTHON_PATH, pythonExecutableName);
+            }
         }
-        if (pythonExecutableName === pythonExecutableNameVenv) {
-            vscode.window.showInformationMessage(
-                CONSTANTS.INFO.UPDATED_TO_EXTENSION_VENV
-            );
-            vscode.workspace
-                .getConfiguration()
-                .update(CONFIG.PYTHON_PATH, pythonExecutableName);
-        } else if (pythonExecutableName === originalPythonExecutableName) {
+        if (pythonExecutableName === originalPythonExecutableName) {
             // going with original interpreter, either because
             // already in venv or error in creating custom venv
             if (checkConfig(CONFIG.SHOW_DEPENDENCY_INSTALL)) {

--- a/src/process_user_code.py
+++ b/src/process_user_code.py
@@ -10,13 +10,10 @@ import threading
 import traceback
 import python_constants as CONSTANTS
 from pathlib import Path
-from pkg_resources import DistributionNotFound, VersionConflict
+import check_python_dependencies
 
-try:
-    import check_python_dependencies
-except (DistributionNotFound,VersionConflict) as e:
-    print("Dependencies are not correct!")
-    quit()
+# will propagate errors if dependencies aren't sufficient
+check_python_dependencies.check_for_dependencies()
 
 read_val = ""
 threads = []

--- a/src/process_user_code.py
+++ b/src/process_user_code.py
@@ -10,6 +10,13 @@ import threading
 import traceback
 import python_constants as CONSTANTS
 from pathlib import Path
+from pkg_resources import DistributionNotFound, VersionConflict
+
+try:
+    import check_python_dependencies
+except (DistributionNotFound,VersionConflict) as e:
+    print("Dependencies are not correct!")
+    quit()
 
 read_val = ""
 threads = []

--- a/src/python_constants.py
+++ b/src/python_constants.py
@@ -5,6 +5,8 @@ ACTIVE_DEVICE_FIELD = "active_device"
 
 CPX_DRIVE_NAME = "CIRCUITPY"
 
+DEPEND_ERR = 'The required dependencies aren\'t downloaded. Please use CTRL+SHIFT+P to open the command palette and select "Device Simulator Express: Install Extension Dependencies".'
+
 DEVICE_NOT_IMPLEMENTED_ERROR = "Device not implemented."
 
 ENABLE_TELEMETRY = "enable_telemetry"


### PR DESCRIPTION
# Description:

Sorry for all of the Venv PR's, everyone 😥😥 !!

Venv fixes:
- If you had a pre-existing extension-created venv but switched to another global interpreter, it wouldn't auto-point back to the extension-created venv.
- Global interpreter wasn't properly switching when you configure a new environment within the same instance that you configured another one (ie: configured for global interpreter 1, but then switch to global interpreter 2 via command prompt or configuration switch detection -> global interpreter 1 would still be the one being used to run Python).

Python Improvements:
If you refuse to install any dependencies, running the code will now give a more helpful message (a suggestion from David in PR #228 !!).

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Limitations:


# Testing:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
