### PR TITLE
Fix venv setup for UNIX

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -471,6 +471,11 @@ export const HELPER_FILES = {
     DEVICE_PY: "device.py",
     PROCESS_USER_CODE_PY: "process_user_code.py",
     PYTHON_EXE: "python.exe",
+    PYTHON: "python",
 };
+
+export const GLOBAL_ENV_VARS = {
+    PYTHON: "python"
+}
 
 export default CONSTANTS;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -475,7 +475,7 @@ export const HELPER_FILES = {
 };
 
 export const GLOBAL_ENV_VARS = {
-    PYTHON: "python"
-}
+    PYTHON: "python",
+};
 
 export default CONSTANTS;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1083,7 +1083,7 @@ const updateCurrentFileIfPython = async (
     if (
         currentTextDocument &&
         utils.getActiveEditorFromPath(currentTextDocument.fileName) ===
-        undefined
+            undefined
     ) {
         await vscode.window.showTextDocument(
             currentTextDocument,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as open from "open";
+import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import {
@@ -12,6 +13,7 @@ import {
     CPX_CONFIG_FILE,
     DEFAULT_DEVICE,
     DialogResponses,
+    GLOBAL_ENV_VARS,
     HELPER_FILES,
     SERVER_INFO,
     TelemetryEventName,
@@ -34,7 +36,7 @@ import { registerDefaultFontFaces } from "office-ui-fabric-react";
 let currentFileAbsPath: string = "";
 let currentTextDocument: vscode.TextDocument;
 let telemetryAI: TelemetryAI;
-let pythonExecutableName: string = "python";
+let pythonExecutablePath: string = GLOBAL_ENV_VARS.PYTHON;
 let configFileCreated: boolean = false;
 let inDebugMode: boolean = false;
 // Notification booleans
@@ -98,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // doesn't trigger lint errors
     updatePylintArgs(context);
 
-    pythonExecutableName = await utils.setupEnv(context);
+    pythonExecutablePath = await utils.setupEnv(context);
 
     try {
         utils.generateCPXConfig();
@@ -108,7 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
         configFileCreated = false;
     }
 
-    if (pythonExecutableName === "") {
+    if (pythonExecutablePath === "") {
         return;
     }
 
@@ -442,7 +444,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const installDependencies: vscode.Disposable = vscode.commands.registerCommand(
         "deviceSimulatorExpress.common.installDependencies",
         async () => {
-            pythonExecutableName = await utils.setupEnv(context, true);
+            pythonExecutablePath = await utils.setupEnv(context, true);
             telemetryAI.trackFeatureUsage(
                 TelemetryEventName.COMMAND_INSTALL_EXTENSION_DEPENDENCIES
             );
@@ -568,7 +570,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 active_device: currentActiveDevice,
             });
 
-            childProcess = cp.spawn(pythonExecutableName, [
+            childProcess = cp.spawn(pythonExecutablePath, [
                 utils.getPathToScript(
                     context,
                     CONSTANTS.FILESYSTEM.OUTPUT_DIRECTORY,
@@ -727,7 +729,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 CONSTANTS.INFO.FILE_SELECTED(currentFileAbsPath)
             );
 
-            const deviceProcess = cp.spawn(pythonExecutableName, [
+            const deviceProcess = cp.spawn(pythonExecutablePath, [
                 utils.getPathToScript(
                     context,
                     CONSTANTS.FILESYSTEM.OUTPUT_DIRECTORY,
@@ -1030,7 +1032,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const configsChanged = vscode.workspace.onDidChangeConfiguration(
         async () => {
             if (utils.checkConfig(CONFIG.CONFIG_ENV_ON_SWITCH)) {
-                pythonExecutableName = await utils.setupEnv(context);
+                pythonExecutablePath = await utils.setupEnv(context);
             }
         }
     );
@@ -1081,7 +1083,7 @@ const updateCurrentFileIfPython = async (
     if (
         currentTextDocument &&
         utils.getActiveEditorFromPath(currentTextDocument.fileName) ===
-            undefined
+        undefined
     ) {
         await vscode.window.showTextDocument(
             currentTextDocument,

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -551,7 +551,7 @@ export const setupEnv = async (
 ) => {
     const originalpythonExecutablePath = await getCurrentpythonExecutablePath();
     let pythonExecutablePath = originalpythonExecutablePath;
-    let pythonExecutableName: string = (os.platform() !== "win32") ? HELPER_FILES.PYTHON_EXE : HELPER_FILES.PYTHON;
+    let pythonExecutableName: string = (os.platform() === "win32") ? HELPER_FILES.PYTHON_EXE : HELPER_FILES.PYTHON;
 
 
     if (!(await areDependenciesInstalled(context, pythonExecutablePath))) {

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -174,10 +174,8 @@ export const isPipInstalled = async (pythonExecutablePath: string) => {
 
     try {
         const { stdout } = await executePythonCommand(pythonExecutablePath, " -m pip");
-        console.log(`uuwuu: ${stdout}`)
         return true;
     } catch (err) {
-        console.log(`uuwuu: ${err}`)
         vscode.window
             .showErrorMessage(
                 CONSTANTS.ERROR.NO_PIP,
@@ -295,7 +293,6 @@ export const executePythonCommand = async (
     pythonExecutablePath: string,
     command: string
 ) => {
-    console.log(`DSE COMMAND: ${createEscapedPath(pythonExecutablePath)} ${command}`)
     return exec(`${createEscapedPath(pythonExecutablePath)} ${command}`);
 };
 

--- a/src/extension_utils/utils.ts
+++ b/src/extension_utils/utils.ts
@@ -86,7 +86,7 @@ export function tryParseJSON(jsonString: string): any | boolean {
         if (jsonObj && typeof jsonObj === "object") {
             return jsonObj;
         }
-    } catch (exception) { }
+    } catch (exception) {}
 
     return false;
 }
@@ -171,9 +171,11 @@ export function generateCPXConfig(): void {
 }
 
 export const isPipInstalled = async (pythonExecutablePath: string) => {
-
     try {
-        const { stdout } = await executePythonCommand(pythonExecutablePath, " -m pip");
+        const { stdout } = await executePythonCommand(
+            pythonExecutablePath,
+            " -m pip"
+        );
         return true;
     } catch (err) {
         vscode.window
@@ -346,7 +348,11 @@ export const promptInstallVenv = (
         )
         .then((selection: vscode.MessageItem | undefined) => {
             if (selection === DialogResponses.YES) {
-                return installPythonVenv(context, pythonExecutable, pythonExecutableName);
+                return installPythonVenv(
+                    context,
+                    pythonExecutable,
+                    pythonExecutableName
+                );
             } else {
                 // return pythonExecutable, notifying the caller
                 // that the user was unwilling to create venv
@@ -357,7 +363,10 @@ export const promptInstallVenv = (
         });
 };
 
-export const getPythonVenv = async (context: vscode.ExtensionContext, pythonExecutableName: string) => {
+export const getPythonVenv = async (
+    context: vscode.ExtensionContext,
+    pythonExecutableName: string
+) => {
     const subFolder = os.platform() === "win32" ? "Scripts" : "bin";
 
     return getPathToScript(
@@ -379,7 +388,10 @@ export const installPythonVenv = async (
 
     vscode.window.showInformationMessage(CONSTANTS.INFO.INSTALLING_PYTHON_VENV);
 
-    const pythonPath: string = await getPythonVenv(context, pythonExecutableName);
+    const pythonPath: string = await getPythonVenv(
+        context,
+        pythonExecutableName
+    );
 
     try {
         // make venv
@@ -485,13 +497,11 @@ export const installDependenciesWrapper = async (
 export const getCurrentpythonExecutablePath = async () => {
     let originalpythonExecutablePath = "";
 
-
     // try to get name from interpreter
     try {
         originalpythonExecutablePath = getConfig(CONFIG.PYTHON_PATH);
     } catch (err) {
-        originalpythonExecutablePath =
-            GLOBAL_ENV_VARS.PYTHON;
+        originalpythonExecutablePath = GLOBAL_ENV_VARS.PYTHON;
     }
 
     if (
@@ -499,8 +509,11 @@ export const getCurrentpythonExecutablePath = async () => {
         originalpythonExecutablePath === ""
     ) {
         try {
-            const { stdout } = await executePythonCommand(GLOBAL_ENV_VARS.PYTHON, `-c "import sys; print(sys.executable)"`)
-            originalpythonExecutablePath = stdout.trim()
+            const { stdout } = await executePythonCommand(
+                GLOBAL_ENV_VARS.PYTHON,
+                `-c "import sys; print(sys.executable)"`
+            );
+            originalpythonExecutablePath = stdout.trim();
         } catch (err) {
             vscode.window
                 .showErrorMessage(
@@ -548,13 +561,18 @@ export const setupEnv = async (
 ) => {
     const originalpythonExecutablePath = await getCurrentpythonExecutablePath();
     let pythonExecutablePath = originalpythonExecutablePath;
-    let pythonExecutableName: string = (os.platform() === "win32") ? HELPER_FILES.PYTHON_EXE : HELPER_FILES.PYTHON;
-
+    let pythonExecutableName: string =
+        os.platform() === "win32"
+            ? HELPER_FILES.PYTHON_EXE
+            : HELPER_FILES.PYTHON;
 
     if (!(await areDependenciesInstalled(context, pythonExecutablePath))) {
         // environment needs to install dependencies
         if (!(await checkIfVenv(context, pythonExecutablePath))) {
-            const pythonExecutablePathVenv = await getPythonVenv(context, pythonExecutableName);
+            const pythonExecutablePathVenv = await getPythonVenv(
+                context,
+                pythonExecutableName
+            );
             if (await hasVenv(context)) {
                 // venv in extention exists with wrong dependencies
                 if (


### PR DESCRIPTION
# Description:

Venv flow is not working on UNIX 😔😔😔😔. It's because I forgot that python.exe on UNIX was just called python :0. Here's the fix!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:


# Testing:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
