### PR TITLE
removed readme badges and changed date on release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
 # Device Simulator Express, a Microsoft Garage project
 
-<a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.7%2B-blue.svg" alt="Python versions: 3.7+" /></a> <img src="https://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active – The project has reached a stable, usable state and is being actively developed." /> <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: We are using the MIT License"></a> <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen.svg" alt="We are welcoming PRS!"></a>  <img src="https://img.shields.io/badge/platform-win%20%7C%20osx-lightgrey.svg" alt="Platforms Supported: Windows, MacOSX"/>
-
-<a href="https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_boards/board/t/227906bb-31ac-4b07-8626-3d757754a616/Microsoft.RequirementCategory/"><img src="https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/227906bb-31ac-4b07-8626-3d757754a616/_apis/work/boardbadge/73f82653-3da1-4a6f-bb79-c91c9eecec28" alt="Azure DevOps Board Badge" /></a>
-
 Make without limit! Device Simulator Express, a Microsoft Garage project, allows you to code microcontrollers without the hardware on hand! You can program your Circuit Playground Express (CPX) or your BBC micro:bit! Test and debug your code on the device simulator and see the same
 result when you plug in your actual microcontroller. Curious about the output of the device, the serial
 monitor allows you to observe the device output.
 
 <img alt='CircuitPlayground Express' src=https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/cpx.jpg>
-
-## Build Status
-
-| Branch  |                                                                                                                Build Status                                                                                                                 |
-| :------ | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| dev     |    [![Build Status](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_apis/build/status/Adafruit/Pacifica-CI?branchName=dev)](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_build/latest?definitionId=304&branchName=dev)    |
-| staging |   [![Build Status](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_apis/build/status/Adafruit/Pacifica-CI?branchName=staging)](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_build/latest?definitionId=304&branchName=staging)    |
-| master  | [![Build Status](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_apis/build/status/Adafruit/Pacifica-CI?branchName=master)](https://microsoftgarage.visualstudio.com/Intern%20GitHub/_build/latest?definitionId=304&branchName=master) |
 
 
 ## Prerequisites

--- a/src/latest_release_note.ts
+++ b/src/latest_release_note.ts
@@ -1,5 +1,5 @@
 // TODO: find a better way of loading html into a string
-export const LATEST_RELEASE_NOTE = `<h1>Device Simulator Express Release Notes 👩🏾‍💻 👨🏾‍💻 (Feb. 27, 2020)</h1>
+export const LATEST_RELEASE_NOTE = `<h1>Device Simulator Express Release Notes 👩🏾‍💻 👨🏾‍💻 (Mar. 2, 2020)</h1>
 <p>
     Welcome to the first update to the Device Simulator Express! <u>Please feel free to enable our feature flag in
         Settings


### PR DESCRIPTION
# Description:

Some last quick changes for release (ONLY DOCS CHANGES).

- You can't package the application when the README has SVGs -> as a result, we removed them here
- Changed the date in the release note to match today's release

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

# Testing:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
