### PR TITLE
Fix issue on mac os when using track_event

### DIFF
--- a/src/common/telemetry.py
+++ b/src/common/telemetry.py
@@ -1,4 +1,7 @@
+import sys
+
 from applicationinsights import TelemetryClient
+from common import constants as CONSTANTS
 from .telemetry_events import TelemetryEvent
 
 
@@ -17,6 +20,7 @@ class Telemetry:
             self.__enable_telemetry
             and self.telemetry_available()
             and not self.telemetry_state[event_name.name]
+            and not sys.platform.startswith(CONSTANTS.MAC_OS)
         ):
             self.telemetry_client.track_event(
                 f"{self.extension_name}/{event_name.value}"


### PR DESCRIPTION
# Description:
Hotfix: do not send python telemetry with application insights on mac os

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
