### PR TITLE
Allows unicode characters (eg. Japanese) in the python files that are run in the simulator

### DIFF
--- a/src/debug_user_code.py
+++ b/src/debug_user_code.py
@@ -51,7 +51,7 @@ cpx.pixels._Pixel__set_debug_mode(True)
 mb._MicrobitModel__set_debug_mode(True)
 
 # Execute the user's code file
-with open(abs_path_to_code_file) as user_code_file:
+with open(abs_path_to_code_file, encoding="utf8") as user_code_file:
     user_code = user_code_file.read()
     try:
         codeObj = compile(user_code, abs_path_to_code_file, CONSTANTS.EXEC_COMMAND)

--- a/src/process_user_code.py
+++ b/src/process_user_code.py
@@ -84,7 +84,7 @@ user_prints.start()
 def execute_user_code(abs_path_to_code_file):
     cpx._Express__abs_path_to_code_file = abs_path_to_code_file
     # Execute the user's code.py file
-    with open(abs_path_to_code_file) as user_code_file:
+    with open(abs_path_to_code_file, encoding="utf8") as user_code_file:
         user_code = user_code_file.read()
         try:
             codeObj = compile(user_code, abs_path_to_code_file, CONSTANTS.EXEC_COMMAND)


### PR DESCRIPTION
# Description:

- Allows unicode characters (eg. Japanese) in the python files that are run in the simulator
- Changed encoding to "utf8" for when files are open

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
