### PR TITLE
HOTFIX: Ubuntu setup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ You will be prompted to install the Python dependencies during the first use.
 - _**[Python 3.7+](https://www.python.org/downloads/)**_: Make sure you've added python and pip to your PATH in your environment variables. (1)
 - _**[Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)**_: This will be installed automatically from the marketplace when you install Device Simulator Express.
 
+### Linux-only Requirements
+To successfully run the virtual environment setup on your first run, please run the following command: `sudo apt install python3.8-venv`
+
 ## Circuit Playground Express (CPX) Simulator
 
 ### Features

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ import { DeviceSelectionService } from "./service/deviceSelectionService";
 import { FileSelectionService } from "./service/fileSelectionService";
 import { MessagingService } from "./service/messagingService";
 import { PopupService } from "./service/PopupService";
-import { SetupService } from "./service/SetupService";
+import { SetupService } from "./service/setupService";
 import { SimulatorDebugConfigurationProvider } from "./simulatorDebugConfigurationProvider";
 import getPackageInfo from "./telemetry/getPackageInfo";
 import TelemetryAI from "./telemetry/telemetryAI";


### PR DESCRIPTION
# Description:
Hotfixes for #277 

The extension was not working on Ubuntu, likely because the imports were case-sensitive on Linux systems (therefore, some of the imports weren't working and causing the app to crash upon activation). The SetupService import has been fixed for this (See diff on extension.ts)

Also, while replicating the issue, I found that Ubuntu was having difficulty setting up a virtual environment on the extension side. The system was always falling back on system-wide installation. The command to fix this was added to the README.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

# Testing:

Testing with basic Neopixel assignment on CPX and making sure virtual env process does not fallback on system-wide imports.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
