### PR TITLE
Resizing "Enable preview mode" pictures in getting started

### DIFF
--- a/src/view/pages/__snapshots__/gettingStarted.spec.tsx.snap
+++ b/src/view/pages/__snapshots__/gettingStarted.spec.tsx.snap
@@ -222,6 +222,12 @@ exports[`GettingStartedPage component  should render correctly 1`] = `
     <img
       alt="Open settings"
       src="https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/clue/open_settings.PNG"
+      style={
+        Object {
+          "height": "337px",
+          "width": "346px",
+        }
+      }
     />
     <ul>
       <li>
@@ -264,6 +270,12 @@ exports[`GettingStartedPage component  should render correctly 1`] = `
     <img
       alt="Enable preview mode"
       src="https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/clue/check_preview_mode.gif"
+      style={
+        Object {
+          "height": "157px",
+          "width": "333px",
+        }
+      }
     />
     <h3>
       1. Import the the main CLUE library (This is required)

--- a/src/view/pages/gettingStarted.tsx
+++ b/src/view/pages/gettingStarted.tsx
@@ -138,13 +138,13 @@ export class GettingStartedPage extends React.Component {
                         <h2> Tutorial for CLUE </h2>
                         <h3> 0. Enable Preview Mode to use the CLUE (This is required)</h3>
                         <p> a. Access your settings:</p>
-                        <img alt='Open settings' src='https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/clue/open_settings.PNG'></img>
+                        <img alt='Open settings' src='https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/clue/open_settings.PNG' style={{width: '346px', height:'337px'}}></img>
                         <ul>
                             <li>Windows or Linux: press <kbd>Ctrl</kbd> + <kbd>,</kbd> or go to <code>File -> Preferences -> Settings</code></li>
                             <li>Mac: press <kbd>Cmd</kbd> + <kbd>,</kbd> or go to <code>Code -> Preferences -> Settings</code>.</li>
                         </ul>
                         <p> b. Check the <code>"Device Simulator Express: Preview Mode"</code> setting.</p>
-                        <img alt='Enable preview mode' src='https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/clue/check_preview_mode.gif'></img>
+                        <img alt='Enable preview mode' src='https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/assets/readmeFiles/clue/check_preview_mode.gif' style={{width: '333px', height:'157px'}}></img>
                         <h3>
                             1. Import the the main CLUE library (This is
                             required)


### PR DESCRIPTION
# Description:
- Resizing "Enable preview mode" pictures in getting started
- Previously it was too big

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
