### PR TITLE
Added extra public field in clue object

### DIFF
--- a/src/clue/adafruit_clue.py
+++ b/src/clue/adafruit_clue.py
@@ -112,7 +112,6 @@ class _ClueSimpleTextDisplay:
         self._display = board.DISPLAY
         self._colors = colors
         self._label = label
-        # self._display = board.DISPLAY
         self._font = terminalio.FONT
         if font:
             self._font = font
@@ -235,6 +234,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
             CONSTANTS.CLUE_STATE.BUTTON_A: "A",
             CONSTANTS.CLUE_STATE.BUTTON_B: "B",
         }
+        self.display = board.DISPLAY
 
     @property
     def button_a(self):


### PR DESCRIPTION
# Description:

When testing this test: https://github.com/adafruit/Adafruit_CircuitPython_CLUE/blob/master/examples/clue_slideshow.py, I found that there should be a public field in CLUE for the display. I made the small change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# Testing:

https://github.com/adafruit/Adafruit_CircuitPython_CLUE/blob/master/examples/clue_slideshow.py

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
