### PR TITLE
Bug Fix for different values of Pressure on Python and React-side

### DIFF
--- a/src/clue/adafruit_clue.py
+++ b/src/clue/adafruit_clue.py
@@ -205,7 +205,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
         self.__state[CONSTANTS.CLUE_STATE.PROXIMITY] = 0
         self.__state[CONSTANTS.CLUE_STATE.GESTURE] = ""
         self.__state[CONSTANTS.CLUE_STATE.HUMIDITY] = 0
-        self.__state[CONSTANTS.CLUE_STATE.PRESSURE] = 0
+        self.__state[CONSTANTS.CLUE_STATE.PRESSURE] = 1013
         self.__state[CONSTANTS.CLUE_STATE.PIXEL] = neopixel.NeoPixel(
             pin=CONSTANTS.CLUE_PIN, n=1, pixel_order=neopixel.RGB
         )


### PR DESCRIPTION
[AB#34573](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34573)
# Description:
- Sensor for pressure defaults to 1013
- In the Python clue object, pressure defaults to 0, so this has been changed to match the sensor default

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
