### PR TITLE
Fix issue where incorrect device was loaded

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,10 @@ export async function activate(context: vscode.ExtensionContext) {
     const openWebview = () => {
         if (currentPanel && currentPanel.webview) {
             messagingService.setWebview(currentPanel.webview);
+            currentPanel.webview.html = webviewService.getWebviewContent(
+                WEBVIEW_TYPES.SIMULATOR,
+                true
+            );
             currentPanel.reveal(vscode.ViewColumn.Beside);
         } else {
             currentPanel = vscode.window.createWebviewPanel(


### PR DESCRIPTION
# Description:
The incorrect device is loaded whenever multiple devices were loaded in a row, then a rerender of the webview loads the incorrect device.

**Steps to reproduce:**
1- Load device 1
2-Load device 2
3- Hide the webview simulator by switching window 
4- Focus again on webview simulator

Current behaviour: Device 1 will load
Expected behaviour: Device 2 should load

The fix is to load the new html with correct device instead of saving it as a React state. Since rerender can be triggered, the react state can be lost, but html variables will persist.

