### PR TITLE
CLUE unimplemented properties print correctly

### DIFF
--- a/src/clue/adafruit_clue.py
+++ b/src/clue/adafruit_clue.py
@@ -501,7 +501,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
                   print("Touched pad 0")
         """
         telemetry_py.send_telemetry(TelemetryEvent.CLUE_API_TOUCH)
-        utils.print_for_unimplemented_functions(Clue.touch_0.__name__)
+        utils.print_for_unimplemented_functions("touch_0")
 
     @property
     def touch_1(self):
@@ -519,7 +519,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
                   print("Touched pad 1")
         """
         telemetry_py.send_telemetry(TelemetryEvent.CLUE_API_TOUCH)
-        utils.print_for_unimplemented_functions(Clue.touch_1.__name__)
+        utils.print_for_unimplemented_functions("touch_1")
 
     @property
     def touch_2(self):
@@ -537,7 +537,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
                   print("Touched pad 2")
         """
         telemetry_py.send_telemetry(TelemetryEvent.CLUE_API_TOUCH)
-        utils.print_for_unimplemented_functions(Clue.touch_2.__name__)
+        utils.print_for_unimplemented_functions("touch_2")
 
     @property
     def white_leds(self):
@@ -652,7 +652,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
               print(clue.sound_level)
         """
         telemetry_py.send_telemetry(TelemetryEvent.CLUE_API_SOUND)
-        utils.print_for_unimplemented_functions(Clue.sound_level.__name__)
+        utils.print_for_unimplemented_functions("sound_level")
 
     def loud_sound(self, sound_threshold=200):
         """Not Implemented!


### PR DESCRIPTION
[AB#34577](https://microsoftgarage.visualstudio.com/002806e2-ebaa-4672-9d2e-5fe5d29154ef/_workitems/edit/34577)

# Description:
- Previously touch_0, touch_1, touch_2 and sound_level properties in CLUE used to throw an exception when a user tries to run these unimplemented functions
- Now, they currently print the correct information
- To test:
```
from adafruit_clue import clue
 
clue.sea_level_pressure = 1020
 
clue_data = clue.simple_text_display(title="CLUE Sensor Data!", title_scale=2)
clue.sound_level
while True:
    clue_data[0].text = "Touch 0: {}".format(clue.touch_0)
    clue_data[1].text = "Touch 1: {}".format(clue.touch_1)
    clue_data[2].text = "Touch 2: {}".format(clue.touch_2)
    clue_data.show()
```

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
