### PR TITLE
Slideshow Backwards/Forwards Bug Fix

### DIFF
--- a/src/clue/adafruit_slideshow.py
+++ b/src/clue/adafruit_slideshow.py
@@ -164,7 +164,7 @@ class SlideShow:
 
         self._order = order
         self._curr_img = ""
-        self._current_image_index = -1
+        self._current_image_index = None
 
         # load images into main queue
         self.__load_images()
@@ -220,22 +220,37 @@ class SlideShow:
     def __get_next_img(self):
 
         if self.direction == PlayBackDirection.FORWARD:
-            self._current_image_index +=1
-            
-            if (self._current_image_index>= len(self.dir_imgs)):
-                self.__load_images()
+            if self._current_image_index == None:
                 self._current_image_index = 0
+            else:
+                self._current_image_index += 1
+
+            if self._current_image_index >= len(self.dir_imgs):
+
+                if self.loop:
+                    self._current_image_index = 0
+                    self.__load_images()
+                else:
+                    self._current_image_index = len(self.dir_imgs) - 10
+                    return ""
 
         else:
-            self._current_image_index -=1
-            
-            if (self._current_image_index< 0):
-                self.__load_images()
-                self._current_image_index = len(self.dir_imgs)-1
+            if self._current_image_index == None:
+                self._current_image_index = len(self.dir_imgs) - 1
+            else:
+                self._current_image_index -= 1
+
+            if self._current_image_index < 0:
+                if self.loop:
+                    self._current_image_index = len(self.dir_imgs) - 1
+                    self.__load_images()
+                else:
+                    self._current_image_index = 0
+                    return ""
 
         img = self.dir_imgs[self._current_image_index]
         return img
-    
+
     def __load_images(self):
         self.dir_imgs = []
         for d in self.dirs:
@@ -243,7 +258,7 @@ class SlideShow:
                 new_path = os.path.join(self.folder, d)
 
                 # only add bmp imgs
-                if os.path.splitext(new_path)[1] == CONSTANTS.BMP_IMG_ENDING:
+                if os.path.splitext(new_path)[-1] == CONSTANTS.BMP_IMG_ENDING:
                     self.dir_imgs.append(new_path)
             except Image.UnidentifiedImageError as e:
                 continue
@@ -255,7 +270,6 @@ class SlideShow:
             shuffle(self.dir_imgs)
         else:
             self.dir_imgs.sort()
-            
 
     def __advance_with_fade(self):
         if board.DISPLAY.active_group != self:
@@ -267,6 +281,7 @@ class SlideShow:
         while not advance_sucessful:
             new_path = self.__get_next_img()
             if new_path == "":
+                self._img_start = time.monotonic()
                 return False
 
             try:
@@ -325,6 +340,7 @@ class SlideShow:
         while not advance_sucessful:
             new_path = self.__get_next_img()
             if new_path == "":
+                self._img_start = time.monotonic()
                 return False
 
             try:

--- a/src/clue/adafruit_slideshow.py
+++ b/src/clue/adafruit_slideshow.py
@@ -5,7 +5,6 @@ import base64
 from io import BytesIO
 from base_circuitpython import base_cp_constants as CONSTANTS
 import time
-import collections
 from random import shuffle
 import common
 import board
@@ -165,6 +164,7 @@ class SlideShow:
 
         self._order = order
         self._curr_img = ""
+        self._current_image_index = -1
 
         # load images into main queue
         self.__load_images()
@@ -219,41 +219,43 @@ class SlideShow:
 
     def __get_next_img(self):
 
-        # handle empty queue
-        if not len(self.pic_queue):
-            if self.loop:
-                self.__load_images()
-            else:
-                return ""
-
         if self.direction == PlayBackDirection.FORWARD:
-            return self.pic_queue.popleft()
-        else:
-            return self.pic_queue.pop()
+            self._current_image_index +=1
+            
+            if (self._current_image_index>= len(self.dir_imgs)):
+                self.__load_images()
+                self._current_image_index = 0
 
+        else:
+            self._current_image_index -=1
+            
+            if (self._current_image_index< 0):
+                self.__load_images()
+                self._current_image_index = len(self.dir_imgs)-1
+
+        img = self.dir_imgs[self._current_image_index]
+        return img
+    
     def __load_images(self):
-        dir_imgs = []
+        self.dir_imgs = []
         for d in self.dirs:
             try:
                 new_path = os.path.join(self.folder, d)
 
                 # only add bmp imgs
                 if os.path.splitext(new_path)[1] == CONSTANTS.BMP_IMG_ENDING:
-                    dir_imgs.append(new_path)
+                    self.dir_imgs.append(new_path)
             except Image.UnidentifiedImageError as e:
                 continue
 
-        if not len(dir_imgs):
+        if not len(self.dir_imgs):
             raise RuntimeError(CONSTANTS.NO_VALID_IMGS_ERR)
 
         if self._order == PlayBackOrder.RANDOM:
-            shuffle(dir_imgs)
+            shuffle(self.dir_imgs)
         else:
-            dir_imgs.sort()
-
-        # convert list to queue
-        # (must be list beforehand for potential randomization)
-        self.pic_queue = collections.deque(dir_imgs)
+            self.dir_imgs.sort()
+            
 
     def __advance_with_fade(self):
         if board.DISPLAY.active_group != self:


### PR DESCRIPTION
# Description:

Addressing #348 .

When actively changing the playback direction of the clue slideshow, it previously did not correctly navigate back and forth. Made some fixes with the internal list so that it now can navigate correctly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing:

Use the following:
```
from adafruit_clue import clue
from adafruit_slideshow import SlideShow, PlayBackDirection, PlayBackOrder

slideshow = SlideShow(clue.display,folder="pix",auto_advance=False)

while True:
    if clue.button_b:
        slideshow.direction = PlayBackDirection.FORWARD
        slideshow.advance()
    if clue.button_a:
        slideshow.direction = PlayBackDirection.BACKWARD
        slideshow.advance()
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
