### PR TITLE
Fixed print() statements for CLUE display in debug mode

### DIFF
--- a/src/debug_user_code.py
+++ b/src/debug_user_code.py
@@ -65,20 +65,23 @@ utils.debug_mode = True
 # overriding print function so that it shows on clue terminal
 def print_decorator(func):
     global curr_terminal
-    def wrapped_func(*args,**kwargs):
-        curr_terminal.add_str_to_terminal(''.join(args))
-        return func(*args,**kwargs)
+
+    def wrapped_func(*args, **kwargs):
+        curr_terminal.add_str_to_terminal("".join(str(e) for e in args))
+        return func(*args, **kwargs)
+
     return wrapped_func
+
 
 print = print_decorator(print)
 
 # Execute the user's code file
 with open(abs_path_to_code_file, encoding="utf8") as user_code_file:
-    
+    curr_terminal.add_str_to_terminal(CONSTANTS.CODE_START_MSG_CLUE)
     user_code = user_code_file.read()
     try:
         codeObj = compile(user_code, abs_path_to_code_file, CONSTANTS.EXEC_COMMAND)
-        exec(codeObj, {'print':print})
+        exec(codeObj, {"print": print})
         sys.stdout.flush()
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -88,3 +91,5 @@ with open(abs_path_to_code_file, encoding="utf8") as user_code_file:
         for frameIndex in range(2, len(stackTrace) - 1):
             errorMessage += "\t" + str(stackTrace[frameIndex])
         print(e, errorMessage, file=sys.stderr, flush=True)
+    curr_terminal.add_str_to_terminal(CONSTANTS.CODE_FINISHED_MSG_CLUE)
+    board.DISPLAY.show(None)


### PR DESCRIPTION
# Description:

Previously, print statements did not show on the CLUE's display while in debug mode. I added a wrapper for `print()` in debug_user_code.py so that prints would also be sent to the clue display.

I also added starting and ending print statements to each run to match non-debug mode.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing:

Prints should appear both on the clue screen and in vscode's terminal.
```
from adafruit_clue import clue
import datetime
import time

clue_data = clue.simple_text_display(title="Data Screen!", title_scale=1, text_scale=3)

val = 100
for i in range(12):
    val += 1
    clue_data.show_terminal()
    time.sleep(0.5)
    print(val)
    print(f"time {datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}")


for i in range(10):
    val += 1
    clue_data[3].text = "Count: {}".format(val)
    clue_data.show()
    print("shouldn't show until the end")
    time.sleep(0.5)
    
```
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
