### PR TITLE
Fixed Import Error on Linux

### DIFF
--- a/src/base_circuitpython/displayio/group.py
+++ b/src/base_circuitpython/displayio/group.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from PIL import Image
 import adafruit_display_text
 
-from .tile_grid import TileGrid
+from displayio.tile_grid import TileGrid
 from . import constants as CONSTANTS
 
 import common

--- a/src/base_circuitpython/displayio/test/test_group.py
+++ b/src/base_circuitpython/displayio/test/test_group.py
@@ -7,10 +7,10 @@ from unittest import mock
 
 from common import utils
 
-from ..tile_grid import TileGrid
-from ..group import Group
-from ..palette import Palette
-from ..bitmap import Bitmap
+from displayio.tile_grid import TileGrid
+from displayio.group import Group
+from displayio.palette import Palette
+from displayio.bitmap import Bitmap
 from .. import constants as CONSTANTS
 from PIL import Image
 

--- a/src/debug_user_code.py
+++ b/src/debug_user_code.py
@@ -32,11 +32,11 @@ sys.path.insert(0, os.path.join(abs_path_to_parent_dir, CONSTANTS.CLUE))
 # Insert absolute path to Circuitpython libraries for CLUE into sys.path
 sys.path.insert(0, os.path.join(abs_path_to_parent_dir, CONSTANTS.CIRCUITPYTHON))
 
-# get board so we can get terminal handle
-import board
-
 # This import must happen after the sys.path is modified
 from common import debugger_communication_client
+
+# get board so we can get terminal handle
+import board
 
 # get handle to terminal for clue
 curr_terminal = board.DISPLAY.terminal


### PR DESCRIPTION
# Description:

`import board` in debug_user_code.py was causing issues on Linux with imports. Minor modifications were made to ensure that it imports correctly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Limitations:

Please describe limitations of this PR

# Testing:

Tested on Windows and Linux:
```
from adafruit_bitmap_font import bitmap_font
 
from adafruit_clue import clue
from datetime import datetime
import time
 
from adafruit_slideshow import SlideShow, PlayBackDirection, PlayBackOrder
import board
 
    
 
clue_data = clue.simple_text_display(title="Clue Sensor Data!", title_scale=2,)
 
val = 100
for i in range(12):
    val += 1
    clue_data.show_terminal()
    time.sleep(0.5)
    print(val)
    print(f"time {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}")
 
    print(clue_data.text_group.hidden)
for i in range(10):
    val += 1
    clue_data[0].text = "Accelerometer:"
    clue_data[1].text = "Gyro:"
    clue_data[2].text = "Magnetic:"
    clue_data[3].text = "Pressure: {:.3f} hPa".format(val)
    clue_data[4].text = "Altitude: {:.1f} m".format(val)
    clue_data[5].text = "Temperature: {:.1f} C".format(val)
    clue_data[6].text = "Humidity: {:.1f} %".format(val)
    clue_data[7].text = "Proximity: {}".format(val)
    clue_data[8].text = "Gesture: {}".format("flip")
    clue_data.text_group.hidden = False
    clue_data[9].text = "Color: R: {} G: {} B: {} C: {}".format(100, 100, 100, 100)
    clue_data[10].text = "Button A: {}".format(False)
    clue_data[11].text = "Button B: {}".format(False)
    clue_data[12].text = "Touch 0: {}".format(False)
    clue_data[13].text = "Touch 1: {}".format(False)
    
    # clue_data.text_group.hidden = False
    clue_data[14].text = "Touch 2: {}".format(False)
    clue_data.show()
    print("shouldn't show until the end")
    time.sleep(0.5)
    print(clue_data.text_group.hidden)

```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
