### PR TITLE
Improvement to input boxes for simulating sensor data

### DIFF
--- a/src/view/components/toolbar/InputSlider.tsx
+++ b/src/view/components/toolbar/InputSlider.tsx
@@ -38,6 +38,7 @@ class InputSlider extends React.Component<ISliderProps, any, any> {
                             .length
                     }}[.]{0,${nbDecimals > 0 ? 1 : 0}}[0-9]{0,${nbDecimals}}$`}
                     onKeyUp={this.handleOnChange}
+                    style={{ width: this.getMaximumBoxWidth() + "ch" }}
                     aria-label={`${this.props.type} sensor input ${this.props.axisLabel}`}
                 />
                 <span className="sliderArea">
@@ -70,6 +71,15 @@ class InputSlider extends React.Component<ISliderProps, any, any> {
             </div>
         );
     }
+
+    private getMaximumBoxWidth = () => {
+        return (
+            Math.max(
+                this.props.minValue.toString().length,
+                this.props.maxValue.toString().length
+            ) + 2
+        );
+    };
 
     private handleOnChange = (event: any) => {
         const validatedValue = this.validateRange(this.updateValue(event));


### PR DESCRIPTION
# Description:

As described in issue #356, currently in the extension, some numbers do not fit inside the input box in the InputSlider component. This PR introduces the change that sets the width of the input box to the length of the maximum input that the user can change the value to.

Before:
![](https://user-images.githubusercontent.com/33995460/79912611-229ad080-83d7-11ea-9a21-c893a5b1095e.png)
 
After:
![new_slider_box](https://user-images.githubusercontent.com/25239532/80339653-00101980-8814-11ea-830f-83558f9b6667.png)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
