### PR TITLE
Fix typo for import cpx on getting started

### DIFF
--- a/src/view/pages/__snapshots__/gettingStarted.spec.tsx.snap
+++ b/src/view/pages/__snapshots__/gettingStarted.spec.tsx.snap
@@ -59,7 +59,7 @@ exports[`GettingStartedPage component  should render correctly 1`] = `
     <h3
       className="normalFontWeight"
     >
-      Import the Circuit Playground library to use it (This is required)
+      &gt; Import the Circuit Playground library to use it (This is required)
     </h3>
     <span
       className="codeBox"

--- a/src/view/pages/__snapshots__/gettingStarted.spec.tsx.snap
+++ b/src/view/pages/__snapshots__/gettingStarted.spec.tsx.snap
@@ -59,7 +59,7 @@ exports[`GettingStartedPage component  should render correctly 1`] = `
     <h3
       className="normalFontWeight"
     >
-      &gt; Import the micro:bit library to use it (This is required)
+      Import the Circuit Playground library to use it (This is required)
     </h3>
     <span
       className="codeBox"

--- a/src/view/pages/gettingStarted.tsx
+++ b/src/view/pages/gettingStarted.tsx
@@ -49,8 +49,7 @@ export class GettingStartedPage extends React.Component {
                     <div id="CPX" className="inv">
                         <h2> Tutorial for Circuit Playground Express </h2>
                         <h3 className="normalFontWeight">
-                            > Import the micro:bit library to use it (This is
-                            required)
+                            Import the Circuit Playground library to use it (This is required)
                         </h3>
                         <span className="codeBox">
                             <pre className="codeText">from adafruit_circuitplayground import cp</pre>
@@ -250,7 +249,7 @@ export class GettingStartedPage extends React.Component {
                         <p>Press <kbd>F5</kbd> or go to <code>Run -> Start Debugging</code></p>
                         <img alt='Start debugging' src='https://raw.githubusercontent.com/microsoft/vscode-python-devicesimulator/dev/src/view/pages/gettingStartedPictures/debugger/start_debugging.jpg' style={{ width: '390px', height: '142px' }}></img>
                         <h3 className="normalFontWeight">
-                            > Set a breakpoint or multiple breakpoints 
+                            > Set a breakpoint or multiple breakpoints
                         </h3>
                         <p>Stopping at a breakpoint pauses the program at that particular place.</p>
                         <p>Use the debug toolbar or the shortcuts below</p>

--- a/src/view/pages/gettingStarted.tsx
+++ b/src/view/pages/gettingStarted.tsx
@@ -49,7 +49,7 @@ export class GettingStartedPage extends React.Component {
                     <div id="CPX" className="inv">
                         <h2> Tutorial for Circuit Playground Express </h2>
                         <h3 className="normalFontWeight">
-                            Import the Circuit Playground library to use it (This is required)
+                            > Import the Circuit Playground library to use it (This is required)
                         </h3>
                         <span className="codeBox">
                             <pre className="codeText">from adafruit_circuitplayground import cp</pre>


### PR DESCRIPTION
# Description:

Minor PR to fix typo on getting started page for cpx. Remove micro:bit and replace with Circuit Playground.

<img width="398" alt="Screen Shot 2020-05-06 at 6 35 21 PM" src="https://user-images.githubusercontent.com/23067852/81235196-5e818880-8fc8-11ea-9ce4-76f8933fc7f0.png">



Issue referenced here #367