### PR TITLE
Persist tutorial page when hidden 

### DIFF
--- a/src/service/webviewService.ts
+++ b/src/service/webviewService.ts
@@ -42,17 +42,17 @@ export class WebviewService {
                 </script>
                 <script ></script>
                 ${this.loadScript(
-            this.context,
-            webviewType,
-            "out/vendor.js",
-            hasDevice
-        )}
+                    this.context,
+                    webviewType,
+                    "out/vendor.js",
+                    hasDevice
+                )}
                 ${this.loadScript(
-            this.context,
-            webviewType,
-            "out/simulator.js",
-            hasDevice
-        )}
+                    this.context,
+                    webviewType,
+                    "out/simulator.js",
+                    hasDevice
+                )}
               </body>
               </html>`;
     }
@@ -64,7 +64,7 @@ export class WebviewService {
             { preserveFocus: true, viewColumn: vscode.ViewColumn.One },
             {
                 enableScripts: true,
-                retainContextWhenHidden: true
+                retainContextWhenHidden: true,
             }
         );
         this.tutorialPanel.webview.html = this.getWebviewContent(
@@ -90,9 +90,9 @@ export class WebviewService {
         if (hasDevice) {
             attributeString = `${
                 WEBVIEW_ATTRIBUTES_KEY.TYPE
-                }=${attributeValue} ${
+            }=${attributeValue} ${
                 WEBVIEW_ATTRIBUTES_KEY.INITIAL_DEVICE
-                }=${this.deviceSelectionService.getCurrentActiveDevice()}`;
+            }=${this.deviceSelectionService.getCurrentActiveDevice()}`;
         } else {
             attributeString = `${WEBVIEW_ATTRIBUTES_KEY.TYPE}=${attributeValue} `;
         }

--- a/src/service/webviewService.ts
+++ b/src/service/webviewService.ts
@@ -42,17 +42,17 @@ export class WebviewService {
                 </script>
                 <script ></script>
                 ${this.loadScript(
-                    this.context,
-                    webviewType,
-                    "out/vendor.js",
-                    hasDevice
-                )}
+            this.context,
+            webviewType,
+            "out/vendor.js",
+            hasDevice
+        )}
                 ${this.loadScript(
-                    this.context,
-                    webviewType,
-                    "out/simulator.js",
-                    hasDevice
-                )}
+            this.context,
+            webviewType,
+            "out/simulator.js",
+            hasDevice
+        )}
               </body>
               </html>`;
     }
@@ -64,6 +64,7 @@ export class WebviewService {
             { preserveFocus: true, viewColumn: vscode.ViewColumn.One },
             {
                 enableScripts: true,
+                retainContextWhenHidden: true
             }
         );
         this.tutorialPanel.webview.html = this.getWebviewContent(
@@ -89,9 +90,9 @@ export class WebviewService {
         if (hasDevice) {
             attributeString = `${
                 WEBVIEW_ATTRIBUTES_KEY.TYPE
-            }=${attributeValue} ${
+                }=${attributeValue} ${
                 WEBVIEW_ATTRIBUTES_KEY.INITIAL_DEVICE
-            }=${this.deviceSelectionService.getCurrentActiveDevice()}`;
+                }=${this.deviceSelectionService.getCurrentActiveDevice()}`;
         } else {
             attributeString = `${WEBVIEW_ATTRIBUTES_KEY.TYPE}=${attributeValue} `;
         }


### PR DESCRIPTION
# Description:
To persist the state of the getting started webview, we can use https://code.visualstudio.com/api/extension-guides/webview#retaincontextwhenhidden from the vscode API.

 Please note that this has a performance overhead since we keep persist the state in the background. The reason why I am using this versus the alternative which is saving the state as a message and sending it back on reopen: 

1. Smoother experience, since it does not need to reload
2. Loaded Page is fairly lightweight and has no background process
3. Will save the exact position of the user on page.
4. More coherent with the description on #366

This PR addresses #366 
