### PR TITLE
Webview resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5958,9 +5958,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.36.0.tgz",
-            "integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==",
+            "version": "1.45.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
+            "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
             "dev": true
         },
         "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
         "@types/node": "^10.12.21",
         "@types/react": "16.8.6",
         "@types/react-dom": "16.8.4",
-        "@types/vscode": "^1.34.0",
+        "@types/vscode": "^1.45.1",
         "css-loader": "^1.0.0",
         "del": "^4.0.0",
         "event-stream": "^4.0.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,10 @@ export const CONSTANTS = {
         MICROBIT: "micro:bit",
         CLUE: "CLUE",
     },
+    SCRIPT_PATH: {
+        SIMULATOR: "out/simulator.js",
+        VSCODE_API: "out/vscode_import.js",
+    },
     ERROR: {
         BAD_PYTHON_PATH:
             'Your interpreter is not pointing to a valid Python executable. Please select a different interpreter (CTRL+SHIFT+P and type "python.selectInterpreter") and restart the application',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,8 @@ export async function activate(context: vscode.ExtensionContext) {
             messagingService.setWebview(currentPanel.webview);
             currentPanel.webview.html = webviewService.getWebviewContent(
                 WEBVIEW_TYPES.SIMULATOR,
-                true
+                true,
+                currentPanel
             );
             currentPanel.reveal(vscode.ViewColumn.Beside);
         } else {
@@ -158,7 +159,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
             currentPanel.webview.html = webviewService.getWebviewContent(
                 WEBVIEW_TYPES.SIMULATOR,
-                true
+                true,
+                currentPanel
             );
             messagingService.setWebview(currentPanel.webview);
 

--- a/src/service/webviewService.ts
+++ b/src/service/webviewService.ts
@@ -99,7 +99,8 @@ export class WebviewService {
         }
     }
 }
-// Nonce generator taken from vscode extension samples
+// Nonce generator taken from vscode extension samples found here:
+// https://github.com/microsoft/vscode-extension-samples/blob/master/custom-editor-sample/src/util.ts
 function getNonce() {
     let text = "";
     const possible =

--- a/src/vscode_import.ts
+++ b/src/vscode_import.ts
@@ -1,0 +1,3 @@
+declare const acquireVsCodeApi;
+
+const vscode = acquireVsCodeApi();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,10 @@ module.exports = {
     path: path.resolve(__dirname, "out"),
     filename: "[name].js"
   },
-  devtool: "eval-source-map",
+  devServer: {
+    historyApiFallback: true
+  },
+  devtool: "source-map",
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".json"]
   },


### PR DESCRIPTION
This PR addresses #374 . This PR includes the following changes:

-Add Content security policy for scripts with meta tag to only load vscode ressources scripts
-Load local script ressources on Webview using  Webview.asWebviewUri function instead of hardcoding vscode-resources.
-Changes have been made to the configuration of  webpack to not use eval on dev which is forbidden by the content security policy 

The changes follow this sample from the vscode extension team: https://github.com/Microsoft/vscode-extension-samples/blob/master/webview-sample/README.md

Testing scenarios :
These can be done on the html document loaded into the web view in src/service/webviewService.ts 
1. Inject inline html without the bounce hash on the html document lo should be sanitized
2. Loading a script outside of the vscode ressources shouldn’t work
The last two script blocks should be sanitized.
`         
            <body>
                <div id="root"></div>
                <script nonce="${nonce}" src=${vscodeImportPathSrc} ></script>
                <script nonce="${nonce}" src=${scriptSrc} ${attributeString} ></script>
                <script>console.log("This console.log should be sanitized")</script>
                <script src="https://www.external_link.com/external_file.js"></script> 
            </body>
`
