### PR TITLE
remove pillow version to rely on recommended - #377

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ pywin32==227; platform_system == "Windows"
 PyObjC; platform_system == "darwin"
 uflash==1.3.0
 adafruit-circuitpython-fancyled==1.3.3
-Pillow==7.0.0
+Pillow
 adafruit-circuitpython-bitmap_font==1.1.0
 adafruit-circuitpython-display-shapes==1.2.0
 adafruit-circuitpython-neopixel==5.0.0


### PR DESCRIPTION
# Description:

Rely on pillows default version for a given interpreter. 7 doesn't (easily) compile with Python 3.9, which blocks initialization of the extension.
This is a bigger than expected issue as it can break/cause problems with ANY python workspace (ie not ones intended for use with Device Simulator) due to the default "always try to install requirements" extension setting.

This is related to #377 .

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing:

Limited- MacOS 11.2.1, python 3.9.1 (via homebrew).
